### PR TITLE
Update GitHub actions versions (actions/cache in particular)

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -24,12 +24,12 @@ jobs:
     steps:
       - name: Checkout
         # Checkout target revision from git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # all history (required for getting last modified time of files)
       - name: Cache bundle directory
         # Cache ruby bundle directory to speed up build
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
@@ -91,10 +91,10 @@ jobs:
     steps:
       - name: Checkout
         # Checkout target revision from git repository
-        uses: actions/checkout@v2
+        uses: actions/checkout@v4
       - name: Cache bundle directory
         # Cache ruby bundle directory to speed up build
-        uses: actions/cache@v2
+        uses: actions/cache@v4
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}

--- a/.github/workflows/create-glossary.yml
+++ b/.github/workflows/create-glossary.yml
@@ -10,12 +10,12 @@ jobs:
     steps:
       - name: Checkout
         # Checkout target revision from git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # all history (required for getting last modified time of files)
       - name: Cache bundle directory
         # Cache ruby bundle directory to speed up build
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}

--- a/.github/workflows/delete-glossary.yml
+++ b/.github/workflows/delete-glossary.yml
@@ -14,12 +14,12 @@ jobs:
     steps:
       - name: Checkout
         # Checkout target revision from git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # all history (required for getting last modified time of files)
       - name: Cache bundle directory
         # Cache ruby bundle directory to speed up build
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}

--- a/.github/workflows/list-glossaries.yml
+++ b/.github/workflows/list-glossaries.yml
@@ -10,12 +10,12 @@ jobs:
     steps:
       - name: Checkout
         # Checkout target revision from git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           fetch-depth: 0 # all history (required for getting last modified time of files)
       - name: Cache bundle directory
         # Cache ruby bundle directory to speed up build
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -39,7 +39,7 @@ jobs:
         # Deploy the site to surge.sh
         # We use surge.sh for pull-request preview because surge.sh supports custom sub-domain and it fits pull-request preview site.
         run: |
-          surge docs pr-preview-"${{ github.event.pull_request.number }}"-pt-quarkusio.surge.sh
+          surge docs pr-preview-"${{ github.event.pull_request.number }}"-cn-quarkusio.surge.sh
         env:
           SURGE_LOGIN: ${{ secrets.SURGE_LOGIN }}
           SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
@@ -49,7 +49,7 @@ jobs:
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |
-            let body = `Site preview(pt): https://pr-preview-${{ github.event.pull_request.number }}-pt-quarkusio.surge.sh`
+            let body = `Site preview(cn): https://pr-preview-${{ github.event.pull_request.number }}-cn-quarkusio.surge.sh`
             github.issues.createComment({
               issue_number: context.issue.number,
               owner: context.repo.owner,

--- a/.github/workflows/pull-request.yml
+++ b/.github/workflows/pull-request.yml
@@ -9,10 +9,10 @@ jobs:
     steps:
       - name: Checkout base branch
         # To avoid GitHub Secrets compromise, checkout base branch to get reliable (untainted) build scripts
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Checkout merged commit to 'merged' dir
         # Checkout merged commit to 'merged' dir
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
         with:
           ref: ${{ github.event.pull_request.head.sha }}
           path: merged
@@ -23,7 +23,7 @@ jobs:
           cp -r merged/l10n ./
       - name: Cache bundle directory
         # Cache ruby bundle directory to speed up build
-        uses: actions/cache@v3
+        uses: actions/cache@v4
         with:
           path: vendor/bundle
           key: ${{ runner.os }}-gem-${{ hashFiles('**/Gemfile.lock') }}
@@ -45,7 +45,7 @@ jobs:
           SURGE_TOKEN: ${{ secrets.SURGE_TOKEN }}
       - name: Add comment
         # Add comment to the pull request to announce the deployed preview site URL.
-        uses: actions/github-script@v3.1.0
+        uses: actions/github-script@v7
         with:
           github-token: ${{secrets.GITHUB_TOKEN}}
           script: |

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -13,14 +13,14 @@ jobs:
     steps:
       - name: Checkout
         # Checkout target revision from git repository
-        uses: actions/checkout@v3
+        uses: actions/checkout@v4
       - name: Setup build env
         # Setup build environment(install runtime, library, etc.)
         run: |
           bin/setup-build-env-on-ubuntu
       - name: Set up JDK 11
         # Setup JDK 11
-        uses: actions/setup-java@v3
+        uses: actions/setup-java@v4
         with:
           distribution: 'temurin'
           java-version: 11


### PR DESCRIPTION
Since actions/cache v2 is disallowed and would fail the build if used. While at it, applied the use of hashes instead of version tags.


see e.g. https://github.com/quarkusio/cn.quarkus.io/actions/runs/15953562306

> Error: This request has been automatically failed because it uses a deprecated version of `actions/cache: v2`. Please update your workflow to use v3/v4 of actions/cache to avoid interruptions. Learn more: https://github.blog/changelog/2024-12-05-notice-of-upcoming-releases-and-breaking-changes-for-github-actions/#actions-cache-v1-v2-and-actions-toolkit-cache-package-closing-down
