### PR TITLE
Fix CNAME generation

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,7 +134,7 @@ jobs:
           {
             echo "git_user_name=$(./tsujiw config get tsuji.git.user.name)"
             echo "git_user_email=$(./tsujiw config get tsuji.git.user.email)"
-            echo "roq_cname=$(yq -r '.tsuji.roq.cname // \"\"' config/application.yaml)"
+            echo "roq_cname=$(yq -r '.tsuji.roq.cname // ""' config/application.yaml)"
           } >> $GITHUB_OUTPUT
 
       - name: Build


### PR DESCRIPTION
Fix the `yq` expression used to generate the GitHub Pages CNAME file after the ROQ migration.