### PR TITLE
Follow-up fixes after ROQ migration

### DIFF
--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -134,7 +134,7 @@ jobs:
           {
             echo "git_user_name=$(./tsujiw config get tsuji.git.user.name)"
             echo "git_user_email=$(./tsujiw config get tsuji.git.user.email)"
-            echo "roq_cname=$(yq -r '.tsuji.roq.cname // \"\"' config/application.yaml)"
+            echo "roq_cname=$(yq -r '.tsuji.roq.cname // ""' config/application.yaml)"
           } >> $GITHUB_OUTPUT
 
       - name: Build

--- a/.github/workflows/build.yml
+++ b/.github/workflows/build.yml
@@ -29,19 +29,19 @@ jobs:
       issues: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 50
           submodules: recursive
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: '21'
 
       - name: Cache tsuji.jar
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: vendor/tsuji
           key: ${{ runner.os }}-tsuji-${{ hashFiles('config/application.yaml') }}
@@ -109,18 +109,18 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           submodules: recursive
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: '21'
 
       - name: Cache tsuji.jar
-        uses: actions/cache@v5
+        uses: actions/cache@v6
         with:
           path: vendor/tsuji
           key: ${{ runner.os }}-tsuji-${{ hashFiles('config/application.yaml') }}

--- a/.github/workflows/pr-build.yml
+++ b/.github/workflows/pr-build.yml
@@ -33,7 +33,7 @@ jobs:
           done
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: '21'

--- a/.github/workflows/pr-deploy.yml
+++ b/.github/workflows/pr-deploy.yml
@@ -26,11 +26,17 @@ jobs:
         uses: actions/github-script@v9
         with:
           script: |
-            const prs = context.payload.workflow_run.pull_requests;
-            if (!prs || prs.length === 0) {
-              core.setFailed('No pull request found for this workflow run');
+            const { data: prs } =
+              await github.rest.repos.listPullRequestsAssociatedWithCommit({
+                ...context.repo,
+                commit_sha: context.payload.workflow_run.head_sha
+              });
+
+            if (prs.length !== 1) {
+              core.setFailed(`Expected one pull request, found ${prs.length}`);
               return;
             }
+
             core.setOutput('pr_number', prs[0].number);
 
       - name: Read surge domain suffix

--- a/.github/workflows/pr-deploy.yml
+++ b/.github/workflows/pr-deploy.yml
@@ -26,11 +26,14 @@ jobs:
         uses: actions/github-script@v9
         with:
           script: |
-            const { data: prs } =
-              await github.rest.repos.listPullRequestsAssociatedWithCommit({
-                ...context.repo,
-                commit_sha: context.payload.workflow_run.head_sha
-              });
+            const owner = context.payload.workflow_run.head_repository.owner.login;
+            const branch = context.payload.workflow_run.head_branch;
+
+            const { data: prs } = await github.rest.pulls.list({
+              ...context.repo,
+              state: 'all',
+              head: `${owner}:${branch}`
+            });
 
             if (prs.length !== 1) {
               core.setFailed(`Expected one pull request, found ${prs.length}`);
@@ -45,7 +48,7 @@ jobs:
           echo "surge_domain_suffix=$(yq '.tsuji.roq.surge-domain-suffix' config/application.yaml)" >> $GITHUB_OUTPUT
 
       - name: Download site artifact
-        uses: actions/download-artifact@v4
+        uses: actions/download-artifact@v8
         with:
           name: pr-preview-site
           path: docs/

--- a/.github/workflows/sync.yml
+++ b/.github/workflows/sync.yml
@@ -18,13 +18,13 @@ jobs:
       contents: write
     steps:
       - name: Checkout
-        uses: actions/checkout@v6
+        uses: actions/checkout@v7
         with:
           fetch-depth: 50
           submodules: recursive
 
       - name: Set up JDK 21
-        uses: actions/setup-java@v5
+        uses: actions/setup-java@v6
         with:
           distribution: 'temurin'
           java-version: '21'

--- a/config/application.yaml
+++ b/config/application.yaml
@@ -3,7 +3,7 @@ quarkus:
     locations: config/application.local.yaml
 
 tsuji:
-  jar: https://github.com/doc-l10n-kit/tsuji/releases/download/v0.9.1/tsuji.jar
+  jar: https://github.com/doc-l10n-kit/tsuji/releases/download/v0.9.2/tsuji.jar
 
   language:
     from: en-US

--- a/l10n/po/zh_CN/.agents/skills/release-announcement/SKILL.md.po
+++ b/l10n/po/zh_CN/.agents/skills/release-announcement/SKILL.md.po
@@ -503,7 +503,7 @@ msgstr ""
 #: .agents/skills/release-announcement/SKILL.md:236
 #, no-wrap
 msgid "For example:\n"
-msgstr "例如："
+msgstr "例如：\n"
 
 #. type: Fenced code block (yaml)
 #: .agents/skills/release-announcement/SKILL.md:237

--- a/l10n/po/zh_CN/1kcontributors.md.po
+++ b/l10n/po/zh_CN/1kcontributors.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: 1kcontributors.md:1
 #, fuzzy, no-wrap
 msgid "1kcontributors"
-msgstr "1k贡献者"
+msgstr "1kcontributors"
 
 #. type: Yaml Front Matter Hash Value: permalink
 #: 1kcontributors.md:1

--- a/l10n/po/zh_CN/404.md.po
+++ b/l10n/po/zh_CN/404.md.po
@@ -14,7 +14,7 @@ msgstr ""
 #: 404.md:1
 #, fuzzy, no-wrap
 msgid "error-page"
-msgstr "错误页面"
+msgstr "error-page"
 
 #. type: Yaml Front Matter Hash Value: permalink
 #: 404.md:1

--- a/l10n/po/zh_CN/README.md.po
+++ b/l10n/po/zh_CN/README.md.po
@@ -214,7 +214,7 @@ msgstr "`user-story` 用于用户/公司采用Quarkus的故事。\n"
 #: README.md:81
 #, no-wrap
 msgid "`development-tips` used for blogs with tips to develop using Quarkus or Quarkus itself.\n"
-msgstr "`development-tips` 用于带有使用Quarkus或Quarkus本身开发提示的博客。"
+msgstr "`development-tips` 用于带有使用Quarkus或Quarkus本身开发提示的博客。\n"
 
 #. type: Bullet: '  - '
 #: README.md:81

--- a/l10n/po/zh_CN/_guides/guides.md.po
+++ b/l10n/po/zh_CN/_guides/guides.md.po
@@ -15,7 +15,7 @@ msgstr ""
 #: _guides/guides.md:1
 #, fuzzy, no-wrap
 msgid "documentation"
-msgstr "文档"
+msgstr "documentation"
 
 #. type: Yaml Front Matter Hash Value: permalink
 #: _guides/guides.md:1

--- a/l10n/po/zh_CN/_guides/kafka.adoc.po
+++ b/l10n/po/zh_CN/_guides/kafka.adoc.po
@@ -42,17 +42,17 @@ msgstr "link:https://kafka.apache.org[Apache Kafka] 是一个流行的开源分�
 #. type: Plain text
 #: _guides/kafka.adoc
 msgid "*publish* (write) and *subscribe* to (read) streams of events, called _records_."
-msgstr "*发布* (写)以及 *订阅* (读)事件流，称为 _记录_ 。\n"
+msgstr "*发布* (写)以及 *订阅* (读)事件流，称为 _记录_ 。"
 
 #. type: Plain text
 #: _guides/kafka.adoc
 msgid "*store* streams of records durably and reliably inside _topics_."
-msgstr "在 _topic_ 内持久而可靠地 *存储* 流式记录。\n"
+msgstr "在 _topic_ 内持久而可靠地 *存储* 流式记录。"
 
 #. type: Plain text
 #: _guides/kafka.adoc
 msgid "*process* streams of records as they occur or retrospectively."
-msgstr "对流式记录进行起始或回溯*处理*。\n"
+msgstr "对流式记录进行起始或回溯*处理*。"
 
 #. type: Plain text
 #: _guides/kafka.adoc
@@ -560,27 +560,27 @@ msgstr "所有写入dead letter queue中的记录将包含一组关于原始记�
 #. type: Plain text
 #: _guides/kafka.adoc
 msgid "*dead-letter-reason*: the reason of the failure"
-msgstr "*dead-letter-reason* ：失败原因\n"
+msgstr "*dead-letter-reason* ：失败原因"
 
 #. type: Plain text
 #: _guides/kafka.adoc
 msgid "*dead-letter-cause*: the cause of the failure if any"
-msgstr "*dead-letter-cause* ：失败的起因(如果有)。\n"
+msgstr "*dead-letter-cause* ：失败的起因(如果有)。"
 
 #. type: Plain text
 #: _guides/kafka.adoc
 msgid "*dead-letter-topic*: the original topic of the record"
-msgstr "*dead-letter-topic* ：失败记录的原始topic\n"
+msgstr "*dead-letter-topic* ：失败记录的原始topic"
 
 #. type: Plain text
 #: _guides/kafka.adoc
 msgid "*dead-letter-partition*: the original partition of the record (integer mapped to String)"
-msgstr "*dead-letter-partition* ：失败记录的原始分区(integer映射为String)\n"
+msgstr "*dead-letter-partition* ：失败记录的原始分区(integer映射为String)"
 
 #. type: Plain text
 #: _guides/kafka.adoc
 msgid "*dead-letter-offset*: the original offset of the record (long mapped to String)"
-msgstr "*dead-letter-offset* ：失败记录的原始偏移量(long映射为String)\n"
+msgstr "*dead-letter-offset* ：失败记录的原始偏移量(long映射为String)"
 
 #. type: Plain text
 #: _guides/kafka.adoc
@@ -691,7 +691,7 @@ msgstr "让我们简单展示一下不同的生产者/消费者模式以及如�
 #. type: Plain text
 #: _guides/kafka.adoc
 msgid "*Single consumer thread inside a consumer group*"
-msgstr "*消费者组内使用单一消费者线程*\n"
+msgstr "*消费者组内使用单一消费者线程*"
 
 #. type: Plain text
 #: _guides/kafka.adoc
@@ -704,7 +704,7 @@ msgstr "这是一个应用程序订阅Kafka topic的默认方式：每个Kafka C
 #. type: Plain text
 #: _guides/kafka.adoc
 msgid "*Multiple consumer threads inside a consumer group*"
-msgstr "*一个消费者组内使用多个消费者线程* \n"
+msgstr "*一个消费者组内使用多个消费者线程* "
 
 #. type: Plain text
 #: _guides/kafka.adoc
@@ -733,7 +733,7 @@ msgstr "link:https://smallrye.io/smallrye-reactive-messaging/latest/concepts/inc
 #. type: Plain text
 #: _guides/kafka.adoc
 msgid "*Multiple consumer applications inside a consumer group*"
-msgstr "*一个消费者组内有多个消费者应用程序* \n"
+msgstr "*一个消费者组内有多个消费者应用程序* "
 
 #. type: Plain text
 #: _guides/kafka.adoc
@@ -745,7 +745,7 @@ msgstr "与前面的例子类似，一个应用程序的多个实例可以订阅
 #. type: Plain text
 #: _guides/kafka.adoc
 msgid "*Pub/Sub: Multiple consumer groups subscribed to a topic*"
-msgstr "*发布/订阅：多个消费者群体订阅同一个topic* \n"
+msgstr "*发布/订阅：多个消费者群体订阅同一个topic* "
 
 #. type: Plain text
 #: _guides/kafka.adoc

--- a/l10n/po/zh_CN/_guides/vertx.adoc.po
+++ b/l10n/po/zh_CN/_guides/vertx.adoc.po
@@ -466,7 +466,7 @@ msgstr ""
 #. type: Plain text
 #: _guides/vertx.adoc
 msgid "You should get the expected `Hello bob` message back."
-msgstr "你应该会收到预期的 `Hello bob` 消息。\n"
+msgstr "你应该会收到预期的 `Hello bob` 消息。"
 
 #. type: Title =
 #: _guides/vertx.adoc
@@ -559,12 +559,12 @@ msgstr "从响应中提取 `langlinks` 数组。"
 #. type: Plain text
 #: _guides/vertx.adoc
 msgid "Then, invoke the endpoint using:"
-msgstr "接着，使用以下命令请求该端点:\n"
+msgstr "接着，使用以下命令请求该端点:"
 
 #. type: Plain text
 #: _guides/vertx.adoc
 msgid "The response indicates that, in addition to the English page, there are a German and a French page about Quarkus on wikipedia."
-msgstr "该响应表明，除了英文页面，维基百科上还有关于 Quarkus 的德文和法文页面。\n"
+msgstr "该响应表明，除了英文页面，维基百科上还有关于 Quarkus 的德文和法文页面。"
 
 #. type: Title =
 #: _guides/vertx.adoc

--- a/l10n/po/zh_CN/_posts/2023-11-02-mandrel-23-0-image-size-increase.md.po
+++ b/l10n/po/zh_CN/_posts/2023-11-02-mandrel-23-0-image-size-increase.md.po
@@ -25,7 +25,7 @@ msgstr "2023-11-02"
 #: _posts/2023-11-02-mandrel-23-0-image-size-increase.md:1
 #, fuzzy, no-wrap
 msgid "post"
-msgstr "邮寄"
+msgstr "post"
 
 #. type: Yaml Front Matter Hash Value: synopsis
 #: _posts/2023-11-02-mandrel-23-0-image-size-increase.md:1

--- a/l10n/po/zh_CN/_posts/2023-11-08-mandrel-23-1-image-size-increase.md.po
+++ b/l10n/po/zh_CN/_posts/2023-11-08-mandrel-23-1-image-size-increase.md.po
@@ -25,7 +25,7 @@ msgstr "2023-11-08"
 #: _posts/2023-11-08-mandrel-23-1-image-size-increase.md:1
 #, fuzzy, no-wrap
 msgid "post"
-msgstr "邮寄"
+msgstr "post"
 
 #. type: Yaml Front Matter Hash Value: synopsis
 #: _posts/2023-11-08-mandrel-23-1-image-size-increase.md:1

--- a/l10n/po/zh_CN/_versions/2.13/guides/guides.md.po
+++ b/l10n/po/zh_CN/_versions/2.13/guides/guides.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: _versions/2.13/guides/guides.md:1
 #, fuzzy, no-wrap
 msgid "documentation"
-msgstr "文档"
+msgstr "documentation"
 
 #. type: Yaml Front Matter Hash Value: permalink
 #: _versions/2.13/guides/guides.md:1

--- a/l10n/po/zh_CN/_versions/2.13/guides/kafka.adoc.po
+++ b/l10n/po/zh_CN/_versions/2.13/guides/kafka.adoc.po
@@ -40,17 +40,17 @@ msgstr "link:https://kafka.apache.org[Apache Kafka] 是一个流行的开源分�
 #. type: Plain text
 #: _versions/2.13/guides/kafka.adoc
 msgid "*publish* (write) and *subscribe* to (read) streams of events, called _records_."
-msgstr "*发布* (写)以及 *订阅* (读)事件流，称为 _记录_ 。\n"
+msgstr "*发布* (写)以及 *订阅* (读)事件流，称为 _记录_ 。"
 
 #. type: Plain text
 #: _versions/2.13/guides/kafka.adoc
 msgid "*store* streams of records durably and reliably inside _topics_."
-msgstr "在 _topic_ 内持久而可靠地 *存储* 流式记录。\n"
+msgstr "在 _topic_ 内持久而可靠地 *存储* 流式记录。"
 
 #. type: Plain text
 #: _versions/2.13/guides/kafka.adoc
 msgid "*process* streams of records as they occur or retrospectively."
-msgstr "对流式记录进行起始或回溯*处理*。\n"
+msgstr "对流式记录进行起始或回溯*处理*。"
 
 #. type: Plain text
 #: _versions/2.13/guides/kafka.adoc
@@ -515,27 +515,27 @@ msgstr "所有写入dead letter queue中的记录将包含一组关于原始记�
 #. type: Plain text
 #: _versions/2.13/guides/kafka.adoc
 msgid "*dead-letter-reason*: the reason of the failure"
-msgstr "*dead-letter-reason* ：失败原因\n"
+msgstr "*dead-letter-reason* ：失败原因"
 
 #. type: Plain text
 #: _versions/2.13/guides/kafka.adoc
 msgid "*dead-letter-cause*: the cause of the failure if any"
-msgstr "*dead-letter-cause* ：失败的起因(如果有)。\n"
+msgstr "*dead-letter-cause* ：失败的起因(如果有)。"
 
 #. type: Plain text
 #: _versions/2.13/guides/kafka.adoc
 msgid "*dead-letter-topic*: the original topic of the record"
-msgstr "*dead-letter-topic* ：失败记录的原始topic\n"
+msgstr "*dead-letter-topic* ：失败记录的原始topic"
 
 #. type: Plain text
 #: _versions/2.13/guides/kafka.adoc
 msgid "*dead-letter-partition*: the original partition of the record (integer mapped to String)"
-msgstr "*dead-letter-partition* ：失败记录的原始分区(integer映射为String)\n"
+msgstr "*dead-letter-partition* ：失败记录的原始分区(integer映射为String)"
 
 #. type: Plain text
 #: _versions/2.13/guides/kafka.adoc
 msgid "*dead-letter-offset*: the original offset of the record (long mapped to String)"
-msgstr "*dead-letter-offset* ：失败记录的原始偏移量(long映射为String)\n"
+msgstr "*dead-letter-offset* ：失败记录的原始偏移量(long映射为String)"
 
 #. type: Plain text
 #: _versions/2.13/guides/kafka.adoc
@@ -631,7 +631,7 @@ msgstr "让我们简单展示一下不同的生产者/消费者模式以及如�
 #. type: Plain text
 #: _versions/2.13/guides/kafka.adoc
 msgid "*Single consumer thread inside a consumer group*"
-msgstr "*消费者组内使用单一消费者线程*\n"
+msgstr "*消费者组内使用单一消费者线程*"
 
 #. type: Plain text
 #: _versions/2.13/guides/kafka.adoc
@@ -644,7 +644,7 @@ msgstr "这是一个应用程序订阅Kafka topic的默认方式：每个Kafka C
 #. type: Plain text
 #: _versions/2.13/guides/kafka.adoc
 msgid "*Multiple consumer threads inside a consumer group*"
-msgstr "*一个消费者组内使用多个消费者线程* \n"
+msgstr "*一个消费者组内使用多个消费者线程* "
 
 #. type: Plain text
 #: _versions/2.13/guides/kafka.adoc
@@ -657,7 +657,7 @@ msgstr "对于一个给定的应用程序实例，消费者组内的消费者数
 #. type: Plain text
 #: _versions/2.13/guides/kafka.adoc
 msgid "*Multiple consumer applications inside a consumer group*"
-msgstr "*一个消费者组内有多个消费者应用程序* \n"
+msgstr "*一个消费者组内有多个消费者应用程序* "
 
 #. type: Plain text
 #: _versions/2.13/guides/kafka.adoc
@@ -669,7 +669,7 @@ msgstr "与前面的例子类似，一个应用程序的多个实例可以订阅
 #. type: Plain text
 #: _versions/2.13/guides/kafka.adoc
 msgid "*Pub/Sub: Multiple consumer groups subscribed to a topic*"
-msgstr "*发布/订阅：多个消费者群体订阅同一个topic* \n"
+msgstr "*发布/订阅：多个消费者群体订阅同一个topic* "
 
 #. type: Plain text
 #: _versions/2.13/guides/kafka.adoc

--- a/l10n/po/zh_CN/_versions/2.13/guides/vertx.adoc.po
+++ b/l10n/po/zh_CN/_versions/2.13/guides/vertx.adoc.po
@@ -461,7 +461,7 @@ msgstr ""
 #. type: Plain text
 #: _versions/2.13/guides/vertx.adoc
 msgid "You should get the expected `Hello bob` message back."
-msgstr "你应该会收到预期的 `Hello bob` 消息。\n"
+msgstr "你应该会收到预期的 `Hello bob` 消息。"
 
 #. type: Title =
 #: _versions/2.13/guides/vertx.adoc
@@ -554,12 +554,12 @@ msgstr "从响应中提取 `langlinks` 数组。"
 #. type: Plain text
 #: _versions/2.13/guides/vertx.adoc
 msgid "Then, invoke the endpoint using:"
-msgstr "接着，使用以下命令请求该端点:\n"
+msgstr "接着，使用以下命令请求该端点:"
 
 #. type: Plain text
 #: _versions/2.13/guides/vertx.adoc
 msgid "The response indicates that, in addition to the English page, there are a German and a French page about Quarkus on wikipedia."
-msgstr "该响应表明，除了英文页面，维基百科上还有关于 Quarkus 的德文和法文页面。\n"
+msgstr "该响应表明，除了英文页面，维基百科上还有关于 Quarkus 的德文和法文页面。"
 
 #. type: Title =
 #: _versions/2.13/guides/vertx.adoc

--- a/l10n/po/zh_CN/_versions/2.16/guides/guides.md.po
+++ b/l10n/po/zh_CN/_versions/2.16/guides/guides.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: _versions/2.16/guides/guides.md:1
 #, fuzzy, no-wrap
 msgid "documentation"
-msgstr "文档"
+msgstr "documentation"
 
 #. type: Yaml Front Matter Hash Value: permalink
 #: _versions/2.16/guides/guides.md:1

--- a/l10n/po/zh_CN/_versions/2.16/guides/kafka.adoc.po
+++ b/l10n/po/zh_CN/_versions/2.16/guides/kafka.adoc.po
@@ -40,17 +40,17 @@ msgstr "link:https://kafka.apache.org[Apache Kafka] 是一个流行的开源分�
 #. type: Plain text
 #: _versions/2.16/guides/kafka.adoc
 msgid "*publish* (write) and *subscribe* to (read) streams of events, called _records_."
-msgstr "*发布* (写)以及 *订阅* (读)事件流，称为 _记录_ 。\n"
+msgstr "*发布* (写)以及 *订阅* (读)事件流，称为 _记录_ 。"
 
 #. type: Plain text
 #: _versions/2.16/guides/kafka.adoc
 msgid "*store* streams of records durably and reliably inside _topics_."
-msgstr "在 _topic_ 内持久而可靠地 *存储* 流式记录。\n"
+msgstr "在 _topic_ 内持久而可靠地 *存储* 流式记录。"
 
 #. type: Plain text
 #: _versions/2.16/guides/kafka.adoc
 msgid "*process* streams of records as they occur or retrospectively."
-msgstr "对流式记录进行起始或回溯*处理*。\n"
+msgstr "对流式记录进行起始或回溯*处理*。"
 
 #. type: Plain text
 #: _versions/2.16/guides/kafka.adoc
@@ -528,27 +528,27 @@ msgstr "所有写入dead letter queue中的记录将包含一组关于原始记�
 #. type: Plain text
 #: _versions/2.16/guides/kafka.adoc
 msgid "*dead-letter-reason*: the reason of the failure"
-msgstr "*dead-letter-reason* ：失败原因\n"
+msgstr "*dead-letter-reason* ：失败原因"
 
 #. type: Plain text
 #: _versions/2.16/guides/kafka.adoc
 msgid "*dead-letter-cause*: the cause of the failure if any"
-msgstr "*dead-letter-cause* ：失败的起因(如果有)。\n"
+msgstr "*dead-letter-cause* ：失败的起因(如果有)。"
 
 #. type: Plain text
 #: _versions/2.16/guides/kafka.adoc
 msgid "*dead-letter-topic*: the original topic of the record"
-msgstr "*dead-letter-topic* ：失败记录的原始topic\n"
+msgstr "*dead-letter-topic* ：失败记录的原始topic"
 
 #. type: Plain text
 #: _versions/2.16/guides/kafka.adoc
 msgid "*dead-letter-partition*: the original partition of the record (integer mapped to String)"
-msgstr "*dead-letter-partition* ：失败记录的原始分区(integer映射为String)\n"
+msgstr "*dead-letter-partition* ：失败记录的原始分区(integer映射为String)"
 
 #. type: Plain text
 #: _versions/2.16/guides/kafka.adoc
 msgid "*dead-letter-offset*: the original offset of the record (long mapped to String)"
-msgstr "*dead-letter-offset* ：失败记录的原始偏移量(long映射为String)\n"
+msgstr "*dead-letter-offset* ：失败记录的原始偏移量(long映射为String)"
 
 #. type: Plain text
 #: _versions/2.16/guides/kafka.adoc
@@ -644,7 +644,7 @@ msgstr "让我们简单展示一下不同的生产者/消费者模式以及如�
 #. type: Plain text
 #: _versions/2.16/guides/kafka.adoc
 msgid "*Single consumer thread inside a consumer group*"
-msgstr "*消费者组内使用单一消费者线程*\n"
+msgstr "*消费者组内使用单一消费者线程*"
 
 #. type: Plain text
 #: _versions/2.16/guides/kafka.adoc
@@ -657,7 +657,7 @@ msgstr "这是一个应用程序订阅Kafka topic的默认方式：每个Kafka C
 #. type: Plain text
 #: _versions/2.16/guides/kafka.adoc
 msgid "*Multiple consumer threads inside a consumer group*"
-msgstr "*一个消费者组内使用多个消费者线程* \n"
+msgstr "*一个消费者组内使用多个消费者线程* "
 
 #. type: Plain text
 #: _versions/2.16/guides/kafka.adoc
@@ -670,7 +670,7 @@ msgstr "对于一个给定的应用程序实例，消费者组内的消费者数
 #. type: Plain text
 #: _versions/2.16/guides/kafka.adoc
 msgid "*Multiple consumer applications inside a consumer group*"
-msgstr "*一个消费者组内有多个消费者应用程序* \n"
+msgstr "*一个消费者组内有多个消费者应用程序* "
 
 #. type: Plain text
 #: _versions/2.16/guides/kafka.adoc
@@ -682,7 +682,7 @@ msgstr "与前面的例子类似，一个应用程序的多个实例可以订阅
 #. type: Plain text
 #: _versions/2.16/guides/kafka.adoc
 msgid "*Pub/Sub: Multiple consumer groups subscribed to a topic*"
-msgstr "*发布/订阅：多个消费者群体订阅同一个topic* \n"
+msgstr "*发布/订阅：多个消费者群体订阅同一个topic* "
 
 #. type: Plain text
 #: _versions/2.16/guides/kafka.adoc

--- a/l10n/po/zh_CN/_versions/2.16/guides/vertx.adoc.po
+++ b/l10n/po/zh_CN/_versions/2.16/guides/vertx.adoc.po
@@ -461,7 +461,7 @@ msgstr ""
 #. type: Plain text
 #: _versions/2.16/guides/vertx.adoc
 msgid "You should get the expected `Hello bob` message back."
-msgstr "你应该会收到预期的 `Hello bob` 消息。\n"
+msgstr "你应该会收到预期的 `Hello bob` 消息。"
 
 #. type: Title =
 #: _versions/2.16/guides/vertx.adoc
@@ -554,12 +554,12 @@ msgstr "从响应中提取 `langlinks` 数组。"
 #. type: Plain text
 #: _versions/2.16/guides/vertx.adoc
 msgid "Then, invoke the endpoint using:"
-msgstr "接着，使用以下命令请求该端点:\n"
+msgstr "接着，使用以下命令请求该端点:"
 
 #. type: Plain text
 #: _versions/2.16/guides/vertx.adoc
 msgid "The response indicates that, in addition to the English page, there are a German and a French page about Quarkus on wikipedia."
-msgstr "该响应表明，除了英文页面，维基百科上还有关于 Quarkus 的德文和法文页面。\n"
+msgstr "该响应表明，除了英文页面，维基百科上还有关于 Quarkus 的德文和法文页面。"
 
 #. type: Title =
 #: _versions/2.16/guides/vertx.adoc

--- a/l10n/po/zh_CN/_versions/2.7/guides/kafka.adoc.po
+++ b/l10n/po/zh_CN/_versions/2.7/guides/kafka.adoc.po
@@ -38,15 +38,15 @@ msgstr "link:https://kafka.apache.org[Apache Kafka] 是一个流行的开源分�
 
 #: _versions/2.7/guides/kafka.adoc
 msgid "*publish* (write) and *subscribe* to (read) streams of events, called _records_."
-msgstr "*发布* (写)以及 *订阅* (读)事件流，称为 _记录_ 。\n"
+msgstr "*发布* (写)以及 *订阅* (读)事件流，称为 _记录_ 。"
 
 #: _versions/2.7/guides/kafka.adoc
 msgid "*store* streams of records durably and reliably inside _topics_."
-msgstr "在 _topic_ 内持久而可靠地 *存储* 流式记录。\n"
+msgstr "在 _topic_ 内持久而可靠地 *存储* 流式记录。"
 
 #: _versions/2.7/guides/kafka.adoc
 msgid "*process* streams of records as they occur or retrospectively."
-msgstr "对流式记录进行起始或回溯*处理*。\n"
+msgstr "对流式记录进行起始或回溯*处理*。"
 
 #. type: Plain text
 #: _versions/2.7/guides/kafka.adoc
@@ -480,23 +480,23 @@ msgstr "所有写入dead letter queue中的记录将包含一组关于原始记�
 
 #: _versions/2.7/guides/kafka.adoc
 msgid "*dead-letter-reason*: the reason of the failure"
-msgstr "*dead-letter-reason* ：失败原因\n"
+msgstr "*dead-letter-reason* ：失败原因"
 
 #: _versions/2.7/guides/kafka.adoc
 msgid "*dead-letter-cause*: the cause of the failure if any"
-msgstr "*dead-letter-cause* ：失败的起因(如果有)。\n"
+msgstr "*dead-letter-cause* ：失败的起因(如果有)。"
 
 #: _versions/2.7/guides/kafka.adoc
 msgid "*dead-letter-topic*: the original topic of the record"
-msgstr "*dead-letter-topic* ：失败记录的原始topic\n"
+msgstr "*dead-letter-topic* ：失败记录的原始topic"
 
 #: _versions/2.7/guides/kafka.adoc
 msgid "*dead-letter-partition*: the original partition of the record (integer mapped to String)"
-msgstr "*dead-letter-partition* ：失败记录的原始分区(integer映射为String)\n"
+msgstr "*dead-letter-partition* ：失败记录的原始分区(integer映射为String)"
 
 #: _versions/2.7/guides/kafka.adoc
 msgid "*dead-letter-offset*: the original offset of the record (long mapped to String)"
-msgstr "*dead-letter-offset* ：失败记录的原始偏移量(long映射为String)\n"
+msgstr "*dead-letter-offset* ：失败记录的原始偏移量(long映射为String)"
 
 #. type: Title ====
 #: _versions/2.7/guides/kafka.adoc
@@ -578,7 +578,7 @@ msgstr "让我们简单展示一下不同的生产者/消费者模式以及如�
 
 #: _versions/2.7/guides/kafka.adoc
 msgid "*Single consumer thread inside a consumer group*"
-msgstr "*消费者组内使用单一消费者线程*\n"
+msgstr "*消费者组内使用单一消费者线程*"
 
 #: _versions/2.7/guides/kafka.adoc
 msgid ""
@@ -589,7 +589,7 @@ msgstr "这是一个应用程序订阅Kafka topic的默认方式：每个Kafka C
 
 #: _versions/2.7/guides/kafka.adoc
 msgid "*Multiple consumer threads inside a consumer group*"
-msgstr "*一个消费者组内使用多个消费者线程* \n"
+msgstr "*一个消费者组内使用多个消费者线程* "
 
 #: _versions/2.7/guides/kafka.adoc
 msgid ""
@@ -600,7 +600,7 @@ msgstr "对于一个给定的应用程序实例，消费者组内的消费者数
 
 #: _versions/2.7/guides/kafka.adoc
 msgid "*Multiple consumer applications inside a consumer group*"
-msgstr "*一个消费者组内有多个消费者应用程序* \n"
+msgstr "*一个消费者组内有多个消费者应用程序* "
 
 #: _versions/2.7/guides/kafka.adoc
 msgid ""
@@ -610,7 +610,7 @@ msgstr "与前面的例子类似，一个应用程序的多个实例可以订阅
 
 #: _versions/2.7/guides/kafka.adoc
 msgid "*Pub/Sub: Multiple consumer groups subscribed to a topic*"
-msgstr "*发布/订阅：多个消费者群体订阅同一个topic* \n"
+msgstr "*发布/订阅：多个消费者群体订阅同一个topic* "
 
 #: _versions/2.7/guides/kafka.adoc
 msgid ""

--- a/l10n/po/zh_CN/_versions/2.7/guides/vertx.adoc.po
+++ b/l10n/po/zh_CN/_versions/2.7/guides/vertx.adoc.po
@@ -426,7 +426,7 @@ msgstr ""
 
 #: _versions/2.7/guides/vertx.adoc
 msgid "You should get the expected `Hello bob` message back."
-msgstr "你应该会收到预期的 `Hello bob` 消息。\n"
+msgstr "你应该会收到预期的 `Hello bob` 消息。"
 
 #. type: Title ==
 #: _versions/2.7/guides/vertx.adoc
@@ -501,11 +501,11 @@ msgstr "从响应中提取 `langlinks` 数组。"
 
 #: _versions/2.7/guides/vertx.adoc
 msgid "Then, invoke the endpoint using:"
-msgstr "接着，使用以下命令请求该端点:\n"
+msgstr "接着，使用以下命令请求该端点:"
 
 #: _versions/2.7/guides/vertx.adoc
 msgid "The response indicates that, in addition to the English page, there are a German and a French page about Quarkus on wikipedia."
-msgstr "该响应表明，除了英文页面，维基百科上还有关于 Quarkus 的德文和法文页面。\n"
+msgstr "该响应表明，除了英文页面，维基百科上还有关于 Quarkus 的德文和法文页面。"
 
 #. type: Title ==
 #: _versions/2.7/guides/vertx.adoc

--- a/l10n/po/zh_CN/_versions/3.15/guides/guides.md.po
+++ b/l10n/po/zh_CN/_versions/3.15/guides/guides.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: _versions/3.15/guides/guides.md:1
 #, fuzzy, no-wrap
 msgid "documentation"
-msgstr "文档"
+msgstr "documentation"
 
 #. type: Yaml Front Matter Hash Value: permalink
 #: _versions/3.15/guides/guides.md:1

--- a/l10n/po/zh_CN/_versions/3.15/guides/kafka.adoc.po
+++ b/l10n/po/zh_CN/_versions/3.15/guides/kafka.adoc.po
@@ -33,17 +33,17 @@ msgstr "link:https://kafka.apache.org[Apache Kafka] 是一个流行的开源分�
 #. type: Plain text
 #: _versions/3.15/guides/kafka.adoc
 msgid "*publish* (write) and *subscribe* to (read) streams of events, called _records_."
-msgstr "*发布* (写)以及 *订阅* (读)事件流，称为 _记录_ 。\n"
+msgstr "*发布* (写)以及 *订阅* (读)事件流，称为 _记录_ 。"
 
 #. type: Plain text
 #: _versions/3.15/guides/kafka.adoc
 msgid "*store* streams of records durably and reliably inside _topics_."
-msgstr "在 _topic_ 内持久而可靠地 *存储* 流式记录。\n"
+msgstr "在 _topic_ 内持久而可靠地 *存储* 流式记录。"
 
 #. type: Plain text
 #: _versions/3.15/guides/kafka.adoc
 msgid "*process* streams of records as they occur or retrospectively."
-msgstr "对流式记录进行起始或回溯*处理*。\n"
+msgstr "对流式记录进行起始或回溯*处理*。"
 
 #. type: Plain text
 #: _versions/3.15/guides/kafka.adoc
@@ -531,27 +531,27 @@ msgstr "所有写入dead letter queue中的记录将包含一组关于原始记�
 #. type: Plain text
 #: _versions/3.15/guides/kafka.adoc
 msgid "*dead-letter-reason*: the reason of the failure"
-msgstr "*dead-letter-reason* ：失败原因\n"
+msgstr "*dead-letter-reason* ：失败原因"
 
 #. type: Plain text
 #: _versions/3.15/guides/kafka.adoc
 msgid "*dead-letter-cause*: the cause of the failure if any"
-msgstr "*dead-letter-cause* ：失败的起因(如果有)。\n"
+msgstr "*dead-letter-cause* ：失败的起因(如果有)。"
 
 #. type: Plain text
 #: _versions/3.15/guides/kafka.adoc
 msgid "*dead-letter-topic*: the original topic of the record"
-msgstr "*dead-letter-topic* ：失败记录的原始topic\n"
+msgstr "*dead-letter-topic* ：失败记录的原始topic"
 
 #. type: Plain text
 #: _versions/3.15/guides/kafka.adoc
 msgid "*dead-letter-partition*: the original partition of the record (integer mapped to String)"
-msgstr "*dead-letter-partition* ：失败记录的原始分区(integer映射为String)\n"
+msgstr "*dead-letter-partition* ：失败记录的原始分区(integer映射为String)"
 
 #. type: Plain text
 #: _versions/3.15/guides/kafka.adoc
 msgid "*dead-letter-offset*: the original offset of the record (long mapped to String)"
-msgstr "*dead-letter-offset* ：失败记录的原始偏移量(long映射为String)\n"
+msgstr "*dead-letter-offset* ：失败记录的原始偏移量(long映射为String)"
 
 #. type: Plain text
 #: _versions/3.15/guides/kafka.adoc
@@ -659,7 +659,7 @@ msgstr "让我们简单展示一下不同的生产者/消费者模式以及如�
 #. type: Plain text
 #: _versions/3.15/guides/kafka.adoc
 msgid "*Single consumer thread inside a consumer group*"
-msgstr "*消费者组内使用单一消费者线程*\n"
+msgstr "*消费者组内使用单一消费者线程*"
 
 #. type: Plain text
 #: _versions/3.15/guides/kafka.adoc
@@ -672,7 +672,7 @@ msgstr "这是一个应用程序订阅Kafka topic的默认方式：每个Kafka C
 #. type: Plain text
 #: _versions/3.15/guides/kafka.adoc
 msgid "*Multiple consumer threads inside a consumer group*"
-msgstr "*一个消费者组内使用多个消费者线程* \n"
+msgstr "*一个消费者组内使用多个消费者线程* "
 
 #. type: Plain text
 #: _versions/3.15/guides/kafka.adoc
@@ -700,7 +700,7 @@ msgstr "link:https://smallrye.io/smallrye-reactive-messaging/latest/concepts/inc
 #. type: Plain text
 #: _versions/3.15/guides/kafka.adoc
 msgid "*Multiple consumer applications inside a consumer group*"
-msgstr "*一个消费者组内有多个消费者应用程序* \n"
+msgstr "*一个消费者组内有多个消费者应用程序* "
 
 #. type: Plain text
 #: _versions/3.15/guides/kafka.adoc
@@ -712,7 +712,7 @@ msgstr "与前面的例子类似，一个应用程序的多个实例可以订阅
 #. type: Plain text
 #: _versions/3.15/guides/kafka.adoc
 msgid "*Pub/Sub: Multiple consumer groups subscribed to a topic*"
-msgstr "*发布/订阅：多个消费者群体订阅同一个topic* \n"
+msgstr "*发布/订阅：多个消费者群体订阅同一个topic* "
 
 #. type: Plain text
 #: _versions/3.15/guides/kafka.adoc

--- a/l10n/po/zh_CN/_versions/3.15/guides/vertx.adoc.po
+++ b/l10n/po/zh_CN/_versions/3.15/guides/vertx.adoc.po
@@ -449,7 +449,7 @@ msgstr ""
 #. type: Plain text
 #: _versions/3.15/guides/vertx.adoc
 msgid "You should get the expected `Hello bob` message back."
-msgstr "你应该会收到预期的 `Hello bob` 消息。\n"
+msgstr "你应该会收到预期的 `Hello bob` 消息。"
 
 #. type: Title =
 #: _versions/3.15/guides/vertx.adoc
@@ -541,12 +541,12 @@ msgstr "从响应中提取 `langlinks` 数组。"
 #. type: Plain text
 #: _versions/3.15/guides/vertx.adoc
 msgid "Then, invoke the endpoint using:"
-msgstr "接着，使用以下命令请求该端点:\n"
+msgstr "接着，使用以下命令请求该端点:"
 
 #. type: Plain text
 #: _versions/3.15/guides/vertx.adoc
 msgid "The response indicates that, in addition to the English page, there are a German and a French page about Quarkus on wikipedia."
-msgstr "该响应表明，除了英文页面，维基百科上还有关于 Quarkus 的德文和法文页面。\n"
+msgstr "该响应表明，除了英文页面，维基百科上还有关于 Quarkus 的德文和法文页面。"
 
 #. type: Title =
 #: _versions/3.15/guides/vertx.adoc

--- a/l10n/po/zh_CN/_versions/3.2/guides/guides.md.po
+++ b/l10n/po/zh_CN/_versions/3.2/guides/guides.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: _versions/3.2/guides/guides.md:1
 #, fuzzy, no-wrap
 msgid "documentation"
-msgstr "文档"
+msgstr "documentation"
 
 #. type: Yaml Front Matter Hash Value: permalink
 #: _versions/3.2/guides/guides.md:1

--- a/l10n/po/zh_CN/_versions/3.2/guides/kafka.adoc.po
+++ b/l10n/po/zh_CN/_versions/3.2/guides/kafka.adoc.po
@@ -40,17 +40,17 @@ msgstr "link:https://kafka.apache.org[Apache Kafka] 是一个流行的开源分�
 #. type: Plain text
 #: _versions/3.2/guides/kafka.adoc
 msgid "*publish* (write) and *subscribe* to (read) streams of events, called _records_."
-msgstr "*发布* (写)以及 *订阅* (读)事件流，称为 _记录_ 。\n"
+msgstr "*发布* (写)以及 *订阅* (读)事件流，称为 _记录_ 。"
 
 #. type: Plain text
 #: _versions/3.2/guides/kafka.adoc
 msgid "*store* streams of records durably and reliably inside _topics_."
-msgstr "在 _topic_ 内持久而可靠地 *存储* 流式记录。\n"
+msgstr "在 _topic_ 内持久而可靠地 *存储* 流式记录。"
 
 #. type: Plain text
 #: _versions/3.2/guides/kafka.adoc
 msgid "*process* streams of records as they occur or retrospectively."
-msgstr "对流式记录进行起始或回溯*处理*。\n"
+msgstr "对流式记录进行起始或回溯*处理*。"
 
 #. type: Plain text
 #: _versions/3.2/guides/kafka.adoc
@@ -532,27 +532,27 @@ msgstr "所有写入dead letter queue中的记录将包含一组关于原始记�
 #. type: Plain text
 #: _versions/3.2/guides/kafka.adoc
 msgid "*dead-letter-reason*: the reason of the failure"
-msgstr "*dead-letter-reason* ：失败原因\n"
+msgstr "*dead-letter-reason* ：失败原因"
 
 #. type: Plain text
 #: _versions/3.2/guides/kafka.adoc
 msgid "*dead-letter-cause*: the cause of the failure if any"
-msgstr "*dead-letter-cause* ：失败的起因(如果有)。\n"
+msgstr "*dead-letter-cause* ：失败的起因(如果有)。"
 
 #. type: Plain text
 #: _versions/3.2/guides/kafka.adoc
 msgid "*dead-letter-topic*: the original topic of the record"
-msgstr "*dead-letter-topic* ：失败记录的原始topic\n"
+msgstr "*dead-letter-topic* ：失败记录的原始topic"
 
 #. type: Plain text
 #: _versions/3.2/guides/kafka.adoc
 msgid "*dead-letter-partition*: the original partition of the record (integer mapped to String)"
-msgstr "*dead-letter-partition* ：失败记录的原始分区(integer映射为String)\n"
+msgstr "*dead-letter-partition* ：失败记录的原始分区(integer映射为String)"
 
 #. type: Plain text
 #: _versions/3.2/guides/kafka.adoc
 msgid "*dead-letter-offset*: the original offset of the record (long mapped to String)"
-msgstr "*dead-letter-offset* ：失败记录的原始偏移量(long映射为String)\n"
+msgstr "*dead-letter-offset* ：失败记录的原始偏移量(long映射为String)"
 
 #. type: Plain text
 #: _versions/3.2/guides/kafka.adoc
@@ -648,7 +648,7 @@ msgstr "让我们简单展示一下不同的生产者/消费者模式以及如�
 #. type: Plain text
 #: _versions/3.2/guides/kafka.adoc
 msgid "*Single consumer thread inside a consumer group*"
-msgstr "*消费者组内使用单一消费者线程*\n"
+msgstr "*消费者组内使用单一消费者线程*"
 
 #. type: Plain text
 #: _versions/3.2/guides/kafka.adoc
@@ -661,7 +661,7 @@ msgstr "这是一个应用程序订阅Kafka topic的默认方式：每个Kafka C
 #. type: Plain text
 #: _versions/3.2/guides/kafka.adoc
 msgid "*Multiple consumer threads inside a consumer group*"
-msgstr "*一个消费者组内使用多个消费者线程* \n"
+msgstr "*一个消费者组内使用多个消费者线程* "
 
 #. type: Plain text
 #: _versions/3.2/guides/kafka.adoc
@@ -674,7 +674,7 @@ msgstr "对于一个给定的应用程序实例，消费者组内的消费者数
 #. type: Plain text
 #: _versions/3.2/guides/kafka.adoc
 msgid "*Multiple consumer applications inside a consumer group*"
-msgstr "*一个消费者组内有多个消费者应用程序* \n"
+msgstr "*一个消费者组内有多个消费者应用程序* "
 
 #. type: Plain text
 #: _versions/3.2/guides/kafka.adoc
@@ -686,7 +686,7 @@ msgstr "与前面的例子类似，一个应用程序的多个实例可以订阅
 #. type: Plain text
 #: _versions/3.2/guides/kafka.adoc
 msgid "*Pub/Sub: Multiple consumer groups subscribed to a topic*"
-msgstr "*发布/订阅：多个消费者群体订阅同一个topic* \n"
+msgstr "*发布/订阅：多个消费者群体订阅同一个topic* "
 
 #. type: Plain text
 #: _versions/3.2/guides/kafka.adoc

--- a/l10n/po/zh_CN/_versions/3.2/guides/vertx.adoc.po
+++ b/l10n/po/zh_CN/_versions/3.2/guides/vertx.adoc.po
@@ -463,7 +463,7 @@ msgstr ""
 #. type: Plain text
 #: _versions/3.2/guides/vertx.adoc
 msgid "You should get the expected `Hello bob` message back."
-msgstr "你应该会收到预期的 `Hello bob` 消息。\n"
+msgstr "你应该会收到预期的 `Hello bob` 消息。"
 
 #. type: Title =
 #: _versions/3.2/guides/vertx.adoc
@@ -556,12 +556,12 @@ msgstr "从响应中提取 `langlinks` 数组。"
 #. type: Plain text
 #: _versions/3.2/guides/vertx.adoc
 msgid "Then, invoke the endpoint using:"
-msgstr "接着，使用以下命令请求该端点:\n"
+msgstr "接着，使用以下命令请求该端点:"
 
 #. type: Plain text
 #: _versions/3.2/guides/vertx.adoc
 msgid "The response indicates that, in addition to the English page, there are a German and a French page about Quarkus on wikipedia."
-msgstr "该响应表明，除了英文页面，维基百科上还有关于 Quarkus 的德文和法文页面。\n"
+msgstr "该响应表明，除了英文页面，维基百科上还有关于 Quarkus 的德文和法文页面。"
 
 #. type: Title =
 #: _versions/3.2/guides/vertx.adoc

--- a/l10n/po/zh_CN/_versions/3.20/guides/guides.md.po
+++ b/l10n/po/zh_CN/_versions/3.20/guides/guides.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: _versions/3.20/guides/guides.md:1
 #, fuzzy, no-wrap
 msgid "documentation"
-msgstr "文档"
+msgstr "documentation"
 
 #. type: Yaml Front Matter Hash Value: permalink
 #: _versions/3.20/guides/guides.md:1

--- a/l10n/po/zh_CN/_versions/3.20/guides/kafka.adoc.po
+++ b/l10n/po/zh_CN/_versions/3.20/guides/kafka.adoc.po
@@ -33,17 +33,17 @@ msgstr "link:https://kafka.apache.org[Apache Kafka] 是一个流行的开源分�
 #. type: Plain text
 #: _versions/3.20/guides/kafka.adoc
 msgid "*publish* (write) and *subscribe* to (read) streams of events, called _records_."
-msgstr "*发布* (写)以及 *订阅* (读)事件流，称为 _记录_ 。\n"
+msgstr "*发布* (写)以及 *订阅* (读)事件流，称为 _记录_ 。"
 
 #. type: Plain text
 #: _versions/3.20/guides/kafka.adoc
 msgid "*store* streams of records durably and reliably inside _topics_."
-msgstr "在 _topic_ 内持久而可靠地 *存储* 流式记录。\n"
+msgstr "在 _topic_ 内持久而可靠地 *存储* 流式记录。"
 
 #. type: Plain text
 #: _versions/3.20/guides/kafka.adoc
 msgid "*process* streams of records as they occur or retrospectively."
-msgstr "对流式记录进行起始或回溯*处理*。\n"
+msgstr "对流式记录进行起始或回溯*处理*。"
 
 #. type: Plain text
 #: _versions/3.20/guides/kafka.adoc
@@ -531,27 +531,27 @@ msgstr "所有写入dead letter queue中的记录将包含一组关于原始记�
 #. type: Plain text
 #: _versions/3.20/guides/kafka.adoc
 msgid "*dead-letter-reason*: the reason of the failure"
-msgstr "*dead-letter-reason* ：失败原因\n"
+msgstr "*dead-letter-reason* ：失败原因"
 
 #. type: Plain text
 #: _versions/3.20/guides/kafka.adoc
 msgid "*dead-letter-cause*: the cause of the failure if any"
-msgstr "*dead-letter-cause* ：失败的起因(如果有)。\n"
+msgstr "*dead-letter-cause* ：失败的起因(如果有)。"
 
 #. type: Plain text
 #: _versions/3.20/guides/kafka.adoc
 msgid "*dead-letter-topic*: the original topic of the record"
-msgstr "*dead-letter-topic* ：失败记录的原始topic\n"
+msgstr "*dead-letter-topic* ：失败记录的原始topic"
 
 #. type: Plain text
 #: _versions/3.20/guides/kafka.adoc
 msgid "*dead-letter-partition*: the original partition of the record (integer mapped to String)"
-msgstr "*dead-letter-partition* ：失败记录的原始分区(integer映射为String)\n"
+msgstr "*dead-letter-partition* ：失败记录的原始分区(integer映射为String)"
 
 #. type: Plain text
 #: _versions/3.20/guides/kafka.adoc
 msgid "*dead-letter-offset*: the original offset of the record (long mapped to String)"
-msgstr "*dead-letter-offset* ：失败记录的原始偏移量(long映射为String)\n"
+msgstr "*dead-letter-offset* ：失败记录的原始偏移量(long映射为String)"
 
 #. type: Plain text
 #: _versions/3.20/guides/kafka.adoc
@@ -659,7 +659,7 @@ msgstr "让我们简单展示一下不同的生产者/消费者模式以及如�
 #. type: Plain text
 #: _versions/3.20/guides/kafka.adoc
 msgid "*Single consumer thread inside a consumer group*"
-msgstr "*消费者组内使用单一消费者线程*\n"
+msgstr "*消费者组内使用单一消费者线程*"
 
 #. type: Plain text
 #: _versions/3.20/guides/kafka.adoc
@@ -672,7 +672,7 @@ msgstr "这是一个应用程序订阅Kafka topic的默认方式：每个Kafka C
 #. type: Plain text
 #: _versions/3.20/guides/kafka.adoc
 msgid "*Multiple consumer threads inside a consumer group*"
-msgstr "*一个消费者组内使用多个消费者线程* \n"
+msgstr "*一个消费者组内使用多个消费者线程* "
 
 #. type: Plain text
 #: _versions/3.20/guides/kafka.adoc
@@ -700,7 +700,7 @@ msgstr "link:https://smallrye.io/smallrye-reactive-messaging/latest/concepts/inc
 #. type: Plain text
 #: _versions/3.20/guides/kafka.adoc
 msgid "*Multiple consumer applications inside a consumer group*"
-msgstr "*一个消费者组内有多个消费者应用程序* \n"
+msgstr "*一个消费者组内有多个消费者应用程序* "
 
 #. type: Plain text
 #: _versions/3.20/guides/kafka.adoc
@@ -712,7 +712,7 @@ msgstr "与前面的例子类似，一个应用程序的多个实例可以订阅
 #. type: Plain text
 #: _versions/3.20/guides/kafka.adoc
 msgid "*Pub/Sub: Multiple consumer groups subscribed to a topic*"
-msgstr "*发布/订阅：多个消费者群体订阅同一个topic* \n"
+msgstr "*发布/订阅：多个消费者群体订阅同一个topic* "
 
 #. type: Plain text
 #: _versions/3.20/guides/kafka.adoc

--- a/l10n/po/zh_CN/_versions/3.20/guides/vertx.adoc.po
+++ b/l10n/po/zh_CN/_versions/3.20/guides/vertx.adoc.po
@@ -449,7 +449,7 @@ msgstr ""
 #. type: Plain text
 #: _versions/3.20/guides/vertx.adoc
 msgid "You should get the expected `Hello bob` message back."
-msgstr "你应该会收到预期的 `Hello bob` 消息。\n"
+msgstr "你应该会收到预期的 `Hello bob` 消息。"
 
 #. type: Title =
 #: _versions/3.20/guides/vertx.adoc
@@ -541,12 +541,12 @@ msgstr "从响应中提取 `langlinks` 数组。"
 #. type: Plain text
 #: _versions/3.20/guides/vertx.adoc
 msgid "Then, invoke the endpoint using:"
-msgstr "接着，使用以下命令请求该端点:\n"
+msgstr "接着，使用以下命令请求该端点:"
 
 #. type: Plain text
 #: _versions/3.20/guides/vertx.adoc
 msgid "The response indicates that, in addition to the English page, there are a German and a French page about Quarkus on wikipedia."
-msgstr "该响应表明，除了英文页面，维基百科上还有关于 Quarkus 的德文和法文页面。\n"
+msgstr "该响应表明，除了英文页面，维基百科上还有关于 Quarkus 的德文和法文页面。"
 
 #. type: Title =
 #: _versions/3.20/guides/vertx.adoc

--- a/l10n/po/zh_CN/_versions/3.27/guides/guides.md.po
+++ b/l10n/po/zh_CN/_versions/3.27/guides/guides.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: _versions/3.27/guides/guides.md:1
 #, fuzzy, no-wrap
 msgid "documentation"
-msgstr "文档"
+msgstr "documentation"
 
 #. type: Yaml Front Matter Hash Value: permalink
 #: _versions/3.27/guides/guides.md:1

--- a/l10n/po/zh_CN/_versions/3.27/guides/kafka.adoc.po
+++ b/l10n/po/zh_CN/_versions/3.27/guides/kafka.adoc.po
@@ -33,17 +33,17 @@ msgstr "link:https://kafka.apache.org[Apache Kafka] 是一个流行的开源分�
 #. type: Plain text
 #: _versions/3.27/guides/kafka.adoc
 msgid "*publish* (write) and *subscribe* to (read) streams of events, called _records_."
-msgstr "*发布* (写)以及 *订阅* (读)事件流，称为 _记录_ 。\n"
+msgstr "*发布* (写)以及 *订阅* (读)事件流，称为 _记录_ 。"
 
 #. type: Plain text
 #: _versions/3.27/guides/kafka.adoc
 msgid "*store* streams of records durably and reliably inside _topics_."
-msgstr "在 _topic_ 内持久而可靠地 *存储* 流式记录。\n"
+msgstr "在 _topic_ 内持久而可靠地 *存储* 流式记录。"
 
 #. type: Plain text
 #: _versions/3.27/guides/kafka.adoc
 msgid "*process* streams of records as they occur or retrospectively."
-msgstr "对流式记录进行起始或回溯*处理*。\n"
+msgstr "对流式记录进行起始或回溯*处理*。"
 
 #. type: Plain text
 #: _versions/3.27/guides/kafka.adoc
@@ -531,27 +531,27 @@ msgstr "所有写入dead letter queue中的记录将包含一组关于原始记�
 #. type: Plain text
 #: _versions/3.27/guides/kafka.adoc
 msgid "*dead-letter-reason*: the reason of the failure"
-msgstr "*dead-letter-reason* ：失败原因\n"
+msgstr "*dead-letter-reason* ：失败原因"
 
 #. type: Plain text
 #: _versions/3.27/guides/kafka.adoc
 msgid "*dead-letter-cause*: the cause of the failure if any"
-msgstr "*dead-letter-cause* ：失败的起因(如果有)。\n"
+msgstr "*dead-letter-cause* ：失败的起因(如果有)。"
 
 #. type: Plain text
 #: _versions/3.27/guides/kafka.adoc
 msgid "*dead-letter-topic*: the original topic of the record"
-msgstr "*dead-letter-topic* ：失败记录的原始topic\n"
+msgstr "*dead-letter-topic* ：失败记录的原始topic"
 
 #. type: Plain text
 #: _versions/3.27/guides/kafka.adoc
 msgid "*dead-letter-partition*: the original partition of the record (integer mapped to String)"
-msgstr "*dead-letter-partition* ：失败记录的原始分区(integer映射为String)\n"
+msgstr "*dead-letter-partition* ：失败记录的原始分区(integer映射为String)"
 
 #. type: Plain text
 #: _versions/3.27/guides/kafka.adoc
 msgid "*dead-letter-offset*: the original offset of the record (long mapped to String)"
-msgstr "*dead-letter-offset* ：失败记录的原始偏移量(long映射为String)\n"
+msgstr "*dead-letter-offset* ：失败记录的原始偏移量(long映射为String)"
 
 #. type: Plain text
 #: _versions/3.27/guides/kafka.adoc
@@ -659,7 +659,7 @@ msgstr "让我们简单展示一下不同的生产者/消费者模式以及如�
 #. type: Plain text
 #: _versions/3.27/guides/kafka.adoc
 msgid "*Single consumer thread inside a consumer group*"
-msgstr "*消费者组内使用单一消费者线程*\n"
+msgstr "*消费者组内使用单一消费者线程*"
 
 #. type: Plain text
 #: _versions/3.27/guides/kafka.adoc
@@ -672,7 +672,7 @@ msgstr "这是一个应用程序订阅Kafka topic的默认方式：每个Kafka C
 #. type: Plain text
 #: _versions/3.27/guides/kafka.adoc
 msgid "*Multiple consumer threads inside a consumer group*"
-msgstr "*一个消费者组内使用多个消费者线程* \n"
+msgstr "*一个消费者组内使用多个消费者线程* "
 
 #. type: Plain text
 #: _versions/3.27/guides/kafka.adoc
@@ -700,7 +700,7 @@ msgstr "link:https://smallrye.io/smallrye-reactive-messaging/latest/concepts/inc
 #. type: Plain text
 #: _versions/3.27/guides/kafka.adoc
 msgid "*Multiple consumer applications inside a consumer group*"
-msgstr "*一个消费者组内有多个消费者应用程序* \n"
+msgstr "*一个消费者组内有多个消费者应用程序* "
 
 #. type: Plain text
 #: _versions/3.27/guides/kafka.adoc
@@ -712,7 +712,7 @@ msgstr "与前面的例子类似，一个应用程序的多个实例可以订阅
 #. type: Plain text
 #: _versions/3.27/guides/kafka.adoc
 msgid "*Pub/Sub: Multiple consumer groups subscribed to a topic*"
-msgstr "*发布/订阅：多个消费者群体订阅同一个topic* \n"
+msgstr "*发布/订阅：多个消费者群体订阅同一个topic* "
 
 #. type: Plain text
 #: _versions/3.27/guides/kafka.adoc

--- a/l10n/po/zh_CN/_versions/3.27/guides/vertx.adoc.po
+++ b/l10n/po/zh_CN/_versions/3.27/guides/vertx.adoc.po
@@ -449,7 +449,7 @@ msgstr ""
 #. type: Plain text
 #: _versions/3.27/guides/vertx.adoc
 msgid "You should get the expected `Hello bob` message back."
-msgstr "你应该会收到预期的 `Hello bob` 消息。\n"
+msgstr "你应该会收到预期的 `Hello bob` 消息。"
 
 #. type: Title =
 #: _versions/3.27/guides/vertx.adoc
@@ -541,12 +541,12 @@ msgstr "从响应中提取 `langlinks` 数组。"
 #. type: Plain text
 #: _versions/3.27/guides/vertx.adoc
 msgid "Then, invoke the endpoint using:"
-msgstr "接着，使用以下命令请求该端点:\n"
+msgstr "接着，使用以下命令请求该端点:"
 
 #. type: Plain text
 #: _versions/3.27/guides/vertx.adoc
 msgid "The response indicates that, in addition to the English page, there are a German and a French page about Quarkus on wikipedia."
-msgstr "该响应表明，除了英文页面，维基百科上还有关于 Quarkus 的德文和法文页面。\n"
+msgstr "该响应表明，除了英文页面，维基百科上还有关于 Quarkus 的德文和法文页面。"
 
 #. type: Title =
 #: _versions/3.27/guides/vertx.adoc

--- a/l10n/po/zh_CN/_versions/3.33/guides/guides.md.po
+++ b/l10n/po/zh_CN/_versions/3.33/guides/guides.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: _versions/3.33/guides/guides.md:1
 #, fuzzy, no-wrap
 msgid "documentation"
-msgstr "文档"
+msgstr "documentation"
 
 #. type: Yaml Front Matter Hash Value: permalink
 #: _versions/3.33/guides/guides.md:1

--- a/l10n/po/zh_CN/_versions/3.34/guides/guides.md.po
+++ b/l10n/po/zh_CN/_versions/3.34/guides/guides.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: _versions/3.34/guides/guides.md:1
 #, fuzzy, no-wrap
 msgid "documentation"
-msgstr "文档"
+msgstr "documentation"
 
 #. type: Yaml Front Matter Hash Value: permalink
 #: _versions/3.34/guides/guides.md:1

--- a/l10n/po/zh_CN/_versions/3.6/guides/kafka.adoc.po
+++ b/l10n/po/zh_CN/_versions/3.6/guides/kafka.adoc.po
@@ -27,15 +27,15 @@ msgstr "link:https://kafka.apache.org[Apache Kafka] 是一个流行的开源分�
 
 #: _versions/3.6/guides/kafka.adoc
 msgid "*publish* (write) and *subscribe* to (read) streams of events, called _records_."
-msgstr "*发布* (写)以及 *订阅* (读)事件流，称为 _记录_ 。\n"
+msgstr "*发布* (写)以及 *订阅* (读)事件流，称为 _记录_ 。"
 
 #: _versions/3.6/guides/kafka.adoc
 msgid "*store* streams of records durably and reliably inside _topics_."
-msgstr "在 _topic_ 内持久而可靠地 *存储* 流式记录。\n"
+msgstr "在 _topic_ 内持久而可靠地 *存储* 流式记录。"
 
 #: _versions/3.6/guides/kafka.adoc
 msgid "*process* streams of records as they occur or retrospectively."
-msgstr "对流式记录进行起始或回溯*处理*。\n"
+msgstr "对流式记录进行起始或回溯*处理*。"
 
 #: _versions/3.6/guides/kafka.adoc
 msgid "And all this functionality is provided in a distributed, highly scalable, elastic, fault-tolerant, and secure manner."
@@ -439,23 +439,23 @@ msgstr "所有写入dead letter queue中的记录将包含一组关于原始记�
 
 #: _versions/3.6/guides/kafka.adoc
 msgid "*dead-letter-reason*: the reason of the failure"
-msgstr "*dead-letter-reason* ：失败原因\n"
+msgstr "*dead-letter-reason* ：失败原因"
 
 #: _versions/3.6/guides/kafka.adoc
 msgid "*dead-letter-cause*: the cause of the failure if any"
-msgstr "*dead-letter-cause* ：失败的起因(如果有)。\n"
+msgstr "*dead-letter-cause* ：失败的起因(如果有)。"
 
 #: _versions/3.6/guides/kafka.adoc
 msgid "*dead-letter-topic*: the original topic of the record"
-msgstr "*dead-letter-topic* ：失败记录的原始topic\n"
+msgstr "*dead-letter-topic* ：失败记录的原始topic"
 
 #: _versions/3.6/guides/kafka.adoc
 msgid "*dead-letter-partition*: the original partition of the record (integer mapped to String)"
-msgstr "*dead-letter-partition* ：失败记录的原始分区(integer映射为String)\n"
+msgstr "*dead-letter-partition* ：失败记录的原始分区(integer映射为String)"
 
 #: _versions/3.6/guides/kafka.adoc
 msgid "*dead-letter-offset*: the original offset of the record (long mapped to String)"
-msgstr "*dead-letter-offset* ：失败记录的原始偏移量(long映射为String)\n"
+msgstr "*dead-letter-offset* ：失败记录的原始偏移量(long映射为String)"
 
 #: _versions/3.6/guides/kafka.adoc
 #, fuzzy
@@ -533,7 +533,7 @@ msgstr "让我们简单展示一下不同的生产者/消费者模式以及如�
 
 #: _versions/3.6/guides/kafka.adoc
 msgid "*Single consumer thread inside a consumer group*"
-msgstr "*消费者组内使用单一消费者线程*\n"
+msgstr "*消费者组内使用单一消费者线程*"
 
 #: _versions/3.6/guides/kafka.adoc
 msgid ""
@@ -544,7 +544,7 @@ msgstr "这是一个应用程序订阅Kafka topic的默认方式：每个Kafka C
 
 #: _versions/3.6/guides/kafka.adoc
 msgid "*Multiple consumer threads inside a consumer group*"
-msgstr "*一个消费者组内使用多个消费者线程* \n"
+msgstr "*一个消费者组内使用多个消费者线程* "
 
 #: _versions/3.6/guides/kafka.adoc
 msgid ""
@@ -555,7 +555,7 @@ msgstr "对于一个给定的应用程序实例，消费者组内的消费者数
 
 #: _versions/3.6/guides/kafka.adoc
 msgid "*Multiple consumer applications inside a consumer group*"
-msgstr "*一个消费者组内有多个消费者应用程序* \n"
+msgstr "*一个消费者组内有多个消费者应用程序* "
 
 #: _versions/3.6/guides/kafka.adoc
 msgid ""
@@ -565,7 +565,7 @@ msgstr "与前面的例子类似，一个应用程序的多个实例可以订阅
 
 #: _versions/3.6/guides/kafka.adoc
 msgid "*Pub/Sub: Multiple consumer groups subscribed to a topic*"
-msgstr "*发布/订阅：多个消费者群体订阅同一个topic* \n"
+msgstr "*发布/订阅：多个消费者群体订阅同一个topic* "
 
 #: _versions/3.6/guides/kafka.adoc
 msgid ""

--- a/l10n/po/zh_CN/_versions/3.6/guides/vertx.adoc.po
+++ b/l10n/po/zh_CN/_versions/3.6/guides/vertx.adoc.po
@@ -368,7 +368,7 @@ msgstr ""
 
 #: _versions/3.6/guides/vertx.adoc
 msgid "You should get the expected `Hello bob` message back."
-msgstr "你应该会收到预期的 `Hello bob` 消息。\n"
+msgstr "你应该会收到预期的 `Hello bob` 消息。"
 
 #: _versions/3.6/guides/vertx.adoc
 msgid "Using Vert.x Clients"
@@ -446,11 +446,11 @@ msgstr "从响应中提取 `langlinks` 数组。"
 
 #: _versions/3.6/guides/vertx.adoc
 msgid "Then, invoke the endpoint using:"
-msgstr "接着，使用以下命令请求该端点:\n"
+msgstr "接着，使用以下命令请求该端点:"
 
 #: _versions/3.6/guides/vertx.adoc
 msgid "The response indicates that, in addition to the English page, there are a German and a French page about Quarkus on wikipedia."
-msgstr "该响应表明，除了英文页面，维基百科上还有关于 Quarkus 的德文和法文页面。\n"
+msgstr "该响应表明，除了英文页面，维基百科上还有关于 Quarkus 的德文和法文页面。"
 
 #: _versions/3.6/guides/vertx.adoc
 #, fuzzy

--- a/l10n/po/zh_CN/_versions/3.8/guides/guides.md.po
+++ b/l10n/po/zh_CN/_versions/3.8/guides/guides.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: _versions/3.8/guides/guides.md:1
 #, fuzzy, no-wrap
 msgid "documentation"
-msgstr "文档"
+msgstr "documentation"
 
 #. type: Yaml Front Matter Hash Value: permalink
 #: _versions/3.8/guides/guides.md:1

--- a/l10n/po/zh_CN/_versions/3.8/guides/kafka.adoc.po
+++ b/l10n/po/zh_CN/_versions/3.8/guides/kafka.adoc.po
@@ -32,17 +32,17 @@ msgstr "link:https://kafka.apache.org[Apache Kafka] 是一个流行的开源分�
 #. type: Plain text
 #: _versions/3.8/guides/kafka.adoc
 msgid "*publish* (write) and *subscribe* to (read) streams of events, called _records_."
-msgstr "*发布* (写)以及 *订阅* (读)事件流，称为 _记录_ 。\n"
+msgstr "*发布* (写)以及 *订阅* (读)事件流，称为 _记录_ 。"
 
 #. type: Plain text
 #: _versions/3.8/guides/kafka.adoc
 msgid "*store* streams of records durably and reliably inside _topics_."
-msgstr "在 _topic_ 内持久而可靠地 *存储* 流式记录。\n"
+msgstr "在 _topic_ 内持久而可靠地 *存储* 流式记录。"
 
 #. type: Plain text
 #: _versions/3.8/guides/kafka.adoc
 msgid "*process* streams of records as they occur or retrospectively."
-msgstr "对流式记录进行起始或回溯*处理*。\n"
+msgstr "对流式记录进行起始或回溯*处理*。"
 
 #. type: Plain text
 #: _versions/3.8/guides/kafka.adoc
@@ -522,27 +522,27 @@ msgstr "所有写入dead letter queue中的记录将包含一组关于原始记�
 #. type: Plain text
 #: _versions/3.8/guides/kafka.adoc
 msgid "*dead-letter-reason*: the reason of the failure"
-msgstr "*dead-letter-reason* ：失败原因\n"
+msgstr "*dead-letter-reason* ：失败原因"
 
 #. type: Plain text
 #: _versions/3.8/guides/kafka.adoc
 msgid "*dead-letter-cause*: the cause of the failure if any"
-msgstr "*dead-letter-cause* ：失败的起因(如果有)。\n"
+msgstr "*dead-letter-cause* ：失败的起因(如果有)。"
 
 #. type: Plain text
 #: _versions/3.8/guides/kafka.adoc
 msgid "*dead-letter-topic*: the original topic of the record"
-msgstr "*dead-letter-topic* ：失败记录的原始topic\n"
+msgstr "*dead-letter-topic* ：失败记录的原始topic"
 
 #. type: Plain text
 #: _versions/3.8/guides/kafka.adoc
 msgid "*dead-letter-partition*: the original partition of the record (integer mapped to String)"
-msgstr "*dead-letter-partition* ：失败记录的原始分区(integer映射为String)\n"
+msgstr "*dead-letter-partition* ：失败记录的原始分区(integer映射为String)"
 
 #. type: Plain text
 #: _versions/3.8/guides/kafka.adoc
 msgid "*dead-letter-offset*: the original offset of the record (long mapped to String)"
-msgstr "*dead-letter-offset* ：失败记录的原始偏移量(long映射为String)\n"
+msgstr "*dead-letter-offset* ：失败记录的原始偏移量(long映射为String)"
 
 #. type: Plain text
 #: _versions/3.8/guides/kafka.adoc
@@ -635,7 +635,7 @@ msgstr "让我们简单展示一下不同的生产者/消费者模式以及如�
 #. type: Plain text
 #: _versions/3.8/guides/kafka.adoc
 msgid "*Single consumer thread inside a consumer group*"
-msgstr "*消费者组内使用单一消费者线程*\n"
+msgstr "*消费者组内使用单一消费者线程*"
 
 #. type: Plain text
 #: _versions/3.8/guides/kafka.adoc
@@ -648,7 +648,7 @@ msgstr "这是一个应用程序订阅Kafka topic的默认方式：每个Kafka C
 #. type: Plain text
 #: _versions/3.8/guides/kafka.adoc
 msgid "*Multiple consumer threads inside a consumer group*"
-msgstr "*一个消费者组内使用多个消费者线程* \n"
+msgstr "*一个消费者组内使用多个消费者线程* "
 
 #. type: Plain text
 #: _versions/3.8/guides/kafka.adoc
@@ -676,7 +676,7 @@ msgstr "link:https://smallrye.io/smallrye-reactive-messaging/latest/concepts/inc
 #. type: Plain text
 #: _versions/3.8/guides/kafka.adoc
 msgid "*Multiple consumer applications inside a consumer group*"
-msgstr "*一个消费者组内有多个消费者应用程序* \n"
+msgstr "*一个消费者组内有多个消费者应用程序* "
 
 #. type: Plain text
 #: _versions/3.8/guides/kafka.adoc
@@ -688,7 +688,7 @@ msgstr "与前面的例子类似，一个应用程序的多个实例可以订阅
 #. type: Plain text
 #: _versions/3.8/guides/kafka.adoc
 msgid "*Pub/Sub: Multiple consumer groups subscribed to a topic*"
-msgstr "*发布/订阅：多个消费者群体订阅同一个topic* \n"
+msgstr "*发布/订阅：多个消费者群体订阅同一个topic* "
 
 #. type: Plain text
 #: _versions/3.8/guides/kafka.adoc

--- a/l10n/po/zh_CN/_versions/3.8/guides/vertx.adoc.po
+++ b/l10n/po/zh_CN/_versions/3.8/guides/vertx.adoc.po
@@ -447,7 +447,7 @@ msgstr ""
 #. type: Plain text
 #: _versions/3.8/guides/vertx.adoc
 msgid "You should get the expected `Hello bob` message back."
-msgstr "你应该会收到预期的 `Hello bob` 消息。\n"
+msgstr "你应该会收到预期的 `Hello bob` 消息。"
 
 #. type: Title =
 #: _versions/3.8/guides/vertx.adoc
@@ -539,12 +539,12 @@ msgstr "从响应中提取 `langlinks` 数组。"
 #. type: Plain text
 #: _versions/3.8/guides/vertx.adoc
 msgid "Then, invoke the endpoint using:"
-msgstr "接着，使用以下命令请求该端点:\n"
+msgstr "接着，使用以下命令请求该端点:"
 
 #. type: Plain text
 #: _versions/3.8/guides/vertx.adoc
 msgid "The response indicates that, in addition to the English page, there are a German and a French page about Quarkus on wikipedia."
-msgstr "该响应表明，除了英文页面，维基百科上还有关于 Quarkus 的德文和法文页面。\n"
+msgstr "该响应表明，除了英文页面，维基百科上还有关于 Quarkus 的德文和法文页面。"
 
 #. type: Title =
 #: _versions/3.8/guides/vertx.adoc

--- a/l10n/po/zh_CN/_versions/main/guides/guides.md.po
+++ b/l10n/po/zh_CN/_versions/main/guides/guides.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: _versions/main/guides/guides.md:1
 #, fuzzy, no-wrap
 msgid "documentation"
-msgstr "文档"
+msgstr "documentation"
 
 #. type: Yaml Front Matter Hash Value: permalink
 #: _versions/main/guides/guides.md:1

--- a/l10n/po/zh_CN/_versions/main/guides/kafka.adoc.po
+++ b/l10n/po/zh_CN/_versions/main/guides/kafka.adoc.po
@@ -40,17 +40,17 @@ msgstr "link:https://kafka.apache.org[Apache Kafka] 是一个流行的开源分�
 #. type: Plain text
 #: _versions/main/guides/kafka.adoc
 msgid "*publish* (write) and *subscribe* to (read) streams of events, called _records_."
-msgstr "*发布* (写)以及 *订阅* (读)事件流，称为 _记录_ 。\n"
+msgstr "*发布* (写)以及 *订阅* (读)事件流，称为 _记录_ 。"
 
 #. type: Plain text
 #: _versions/main/guides/kafka.adoc
 msgid "*store* streams of records durably and reliably inside _topics_."
-msgstr "在 _topic_ 内持久而可靠地 *存储* 流式记录。\n"
+msgstr "在 _topic_ 内持久而可靠地 *存储* 流式记录。"
 
 #. type: Plain text
 #: _versions/main/guides/kafka.adoc
 msgid "*process* streams of records as they occur or retrospectively."
-msgstr "对流式记录进行起始或回溯*处理*。\n"
+msgstr "对流式记录进行起始或回溯*处理*。"
 
 #. type: Plain text
 #: _versions/main/guides/kafka.adoc
@@ -555,27 +555,27 @@ msgstr "所有写入dead letter queue中的记录将包含一组关于原始记�
 #. type: Plain text
 #: _versions/main/guides/kafka.adoc
 msgid "*dead-letter-reason*: the reason of the failure"
-msgstr "*dead-letter-reason* ：失败原因\n"
+msgstr "*dead-letter-reason* ：失败原因"
 
 #. type: Plain text
 #: _versions/main/guides/kafka.adoc
 msgid "*dead-letter-cause*: the cause of the failure if any"
-msgstr "*dead-letter-cause* ：失败的起因(如果有)。\n"
+msgstr "*dead-letter-cause* ：失败的起因(如果有)。"
 
 #. type: Plain text
 #: _versions/main/guides/kafka.adoc
 msgid "*dead-letter-topic*: the original topic of the record"
-msgstr "*dead-letter-topic* ：失败记录的原始topic\n"
+msgstr "*dead-letter-topic* ：失败记录的原始topic"
 
 #. type: Plain text
 #: _versions/main/guides/kafka.adoc
 msgid "*dead-letter-partition*: the original partition of the record (integer mapped to String)"
-msgstr "*dead-letter-partition* ：失败记录的原始分区(integer映射为String)\n"
+msgstr "*dead-letter-partition* ：失败记录的原始分区(integer映射为String)"
 
 #. type: Plain text
 #: _versions/main/guides/kafka.adoc
 msgid "*dead-letter-offset*: the original offset of the record (long mapped to String)"
-msgstr "*dead-letter-offset* ：失败记录的原始偏移量(long映射为String)\n"
+msgstr "*dead-letter-offset* ：失败记录的原始偏移量(long映射为String)"
 
 #. type: Plain text
 #: _versions/main/guides/kafka.adoc
@@ -686,7 +686,7 @@ msgstr "让我们简单展示一下不同的生产者/消费者模式以及如�
 #. type: Plain text
 #: _versions/main/guides/kafka.adoc
 msgid "*Single consumer thread inside a consumer group*"
-msgstr "*消费者组内使用单一消费者线程*\n"
+msgstr "*消费者组内使用单一消费者线程*"
 
 #. type: Plain text
 #: _versions/main/guides/kafka.adoc
@@ -699,7 +699,7 @@ msgstr "这是一个应用程序订阅Kafka topic的默认方式：每个Kafka C
 #. type: Plain text
 #: _versions/main/guides/kafka.adoc
 msgid "*Multiple consumer threads inside a consumer group*"
-msgstr "*一个消费者组内使用多个消费者线程* \n"
+msgstr "*一个消费者组内使用多个消费者线程* "
 
 #. type: Plain text
 #: _versions/main/guides/kafka.adoc
@@ -728,7 +728,7 @@ msgstr "link:https://smallrye.io/smallrye-reactive-messaging/latest/concepts/inc
 #. type: Plain text
 #: _versions/main/guides/kafka.adoc
 msgid "*Multiple consumer applications inside a consumer group*"
-msgstr "*一个消费者组内有多个消费者应用程序* \n"
+msgstr "*一个消费者组内有多个消费者应用程序* "
 
 #. type: Plain text
 #: _versions/main/guides/kafka.adoc
@@ -740,7 +740,7 @@ msgstr "与前面的例子类似，一个应用程序的多个实例可以订阅
 #. type: Plain text
 #: _versions/main/guides/kafka.adoc
 msgid "*Pub/Sub: Multiple consumer groups subscribed to a topic*"
-msgstr "*发布/订阅：多个消费者群体订阅同一个topic* \n"
+msgstr "*发布/订阅：多个消费者群体订阅同一个topic* "
 
 #. type: Plain text
 #: _versions/main/guides/kafka.adoc

--- a/l10n/po/zh_CN/_versions/main/guides/vertx.adoc.po
+++ b/l10n/po/zh_CN/_versions/main/guides/vertx.adoc.po
@@ -463,7 +463,7 @@ msgstr ""
 #. type: Plain text
 #: _versions/main/guides/vertx.adoc
 msgid "You should get the expected `Hello bob` message back."
-msgstr "你应该会收到预期的 `Hello bob` 消息。\n"
+msgstr "你应该会收到预期的 `Hello bob` 消息。"
 
 #. type: Title =
 #: _versions/main/guides/vertx.adoc
@@ -556,12 +556,12 @@ msgstr "从响应中提取 `langlinks` 数组。"
 #. type: Plain text
 #: _versions/main/guides/vertx.adoc
 msgid "Then, invoke the endpoint using:"
-msgstr "接着，使用以下命令请求该端点:\n"
+msgstr "接着，使用以下命令请求该端点:"
 
 #. type: Plain text
 #: _versions/main/guides/vertx.adoc
 msgid "The response indicates that, in addition to the English page, there are a German and a French page about Quarkus on wikipedia."
-msgstr "该响应表明，除了英文页面，维基百科上还有关于 Quarkus 的德文和法文页面。\n"
+msgstr "该响应表明，除了英文页面，维基百科上还有关于 Quarkus 的德文和法文页面。"
 
 #. type: Title =
 #: _versions/main/guides/vertx.adoc

--- a/l10n/po/zh_CN/about.md.po
+++ b/l10n/po/zh_CN/about.md.po
@@ -14,7 +14,7 @@ msgstr ""
 #: about.md:1
 #, fuzzy, no-wrap
 msgid "about"
-msgstr "关于"
+msgstr "about"
 
 #. type: Yaml Front Matter Hash Value: permalink
 #: about.md:1

--- a/l10n/po/zh_CN/ai-agentic.md.po
+++ b/l10n/po/zh_CN/ai-agentic.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: ai-agentic.md:1
 #, fuzzy, no-wrap
 msgid "about"
-msgstr "关于"
+msgstr "about"
 
 #. type: Yaml Front Matter Hash Value: permalink
 #: ai-agentic.md:1

--- a/l10n/po/zh_CN/ai-chain-of-thought.md.po
+++ b/l10n/po/zh_CN/ai-chain-of-thought.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: ai-chain-of-thought.md:1
 #, fuzzy, no-wrap
 msgid "about"
-msgstr "关于"
+msgstr "about"
 
 #. type: Yaml Front Matter Hash Value: permalink
 #: ai-chain-of-thought.md:1

--- a/l10n/po/zh_CN/ai-contextual-rag.md.po
+++ b/l10n/po/zh_CN/ai-contextual-rag.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: ai-contextual-rag.md:1
 #, fuzzy, no-wrap
 msgid "about"
-msgstr "关于"
+msgstr "about"
 
 #. type: Yaml Front Matter Hash Value: permalink
 #: ai-contextual-rag.md:1

--- a/l10n/po/zh_CN/ai-getting-started-with-ai.md.po
+++ b/l10n/po/zh_CN/ai-getting-started-with-ai.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: ai-getting-started-with-ai.md:1
 #, fuzzy, no-wrap
 msgid "about"
-msgstr "关于"
+msgstr "about"
 
 #. type: Yaml Front Matter Hash Value: permalink
 #: ai-getting-started-with-ai.md:1

--- a/l10n/po/zh_CN/author.md.po
+++ b/l10n/po/zh_CN/author.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: author.md:1
 #, fuzzy, no-wrap
 msgid "authors"
-msgstr "作者"
+msgstr "authors"
 
 #. type: Yaml Front Matter Hash Value: permalink
 #: author.md:1

--- a/l10n/po/zh_CN/benefactors.md.po
+++ b/l10n/po/zh_CN/benefactors.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: benefactors.md:1
 #, fuzzy, no-wrap
 msgid "benefactors"
-msgstr "恩人"
+msgstr "benefactors"
 
 #. type: Yaml Front Matter Hash Value: permalink
 #: benefactors.md:1

--- a/l10n/po/zh_CN/blog.md.po
+++ b/l10n/po/zh_CN/blog.md.po
@@ -14,7 +14,7 @@ msgstr ""
 #: blog.md:1
 #, no-wrap
 msgid "blog"
-msgstr "博客"
+msgstr "blog"
 
 #. type: Yaml Front Matter Hash Value: permalink
 #: blog.md:1

--- a/l10n/po/zh_CN/books.md.po
+++ b/l10n/po/zh_CN/books.md.po
@@ -14,7 +14,7 @@ msgstr ""
 #: books.md:1
 #, fuzzy, no-wrap
 msgid "books"
-msgstr "书籍"
+msgstr "books"
 
 #. type: Yaml Front Matter Hash Value: permalink
 #: books.md:1

--- a/l10n/po/zh_CN/brand.md.po
+++ b/l10n/po/zh_CN/brand.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: brand.md:1
 #, fuzzy, no-wrap
 msgid "brand"
-msgstr "品牌"
+msgstr "brand"
 
 #. type: Yaml Front Matter Hash Value: permalink
 #: brand.md:1

--- a/l10n/po/zh_CN/components.md.po
+++ b/l10n/po/zh_CN/components.md.po
@@ -14,7 +14,7 @@ msgstr ""
 #: components.md:1
 #, fuzzy, no-wrap
 msgid "components"
-msgstr "组件"
+msgstr "components"
 
 #. type: Yaml Front Matter Hash Value: title
 #: components.md:1

--- a/l10n/po/zh_CN/container-first.md.po
+++ b/l10n/po/zh_CN/container-first.md.po
@@ -14,7 +14,7 @@ msgstr ""
 #: container-first.md:1
 #, fuzzy, no-wrap
 msgid "container-first"
-msgstr "容器优先"
+msgstr "container-first"
 
 #. type: Yaml Front Matter Hash Value: permalink
 #: container-first.md:1

--- a/l10n/po/zh_CN/content/1kcontributors.md.po
+++ b/l10n/po/zh_CN/content/1kcontributors.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: content/1kcontributors.md:1
 #, fuzzy, no-wrap
 msgid "1kcontributors"
-msgstr "1k贡献者"
+msgstr "1kcontributors"
 
 #. type: Yaml Front Matter Hash Value: link
 #: content/1kcontributors.md:1

--- a/l10n/po/zh_CN/content/404.md.po
+++ b/l10n/po/zh_CN/content/404.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: content/404.md:1
 #, fuzzy, no-wrap
 msgid "error-page"
-msgstr "错误页面"
+msgstr "error-page"
 
 #. type: Yaml Front Matter Hash Value: link
 #: content/404.md:1

--- a/l10n/po/zh_CN/content/about.md.po
+++ b/l10n/po/zh_CN/content/about.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: content/about.md:1
 #, fuzzy, no-wrap
 msgid "about"
-msgstr "关于"
+msgstr "about"
 
 #. type: Yaml Front Matter Hash Value: subtitle
 #: content/about.md:1

--- a/l10n/po/zh_CN/content/ai-agentic.md.po
+++ b/l10n/po/zh_CN/content/ai-agentic.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: content/ai-agentic.md:1
 #, fuzzy, no-wrap
 msgid "about"
-msgstr "关于"
+msgstr "about"
 
 #. type: Yaml Front Matter Hash Value: link
 #: content/ai-agentic.md:1

--- a/l10n/po/zh_CN/content/ai-chain-of-thought.md.po
+++ b/l10n/po/zh_CN/content/ai-chain-of-thought.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: content/ai-chain-of-thought.md:1
 #, fuzzy, no-wrap
 msgid "about"
-msgstr "关于"
+msgstr "about"
 
 #. type: Yaml Front Matter Hash Value: link
 #: content/ai-chain-of-thought.md:1

--- a/l10n/po/zh_CN/content/ai-contextual-rag.md.po
+++ b/l10n/po/zh_CN/content/ai-contextual-rag.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: content/ai-contextual-rag.md:1
 #, fuzzy, no-wrap
 msgid "about"
-msgstr "关于"
+msgstr "about"
 
 #. type: Yaml Front Matter Hash Value: link
 #: content/ai-contextual-rag.md:1

--- a/l10n/po/zh_CN/content/ai-getting-started-with-ai.md.po
+++ b/l10n/po/zh_CN/content/ai-getting-started-with-ai.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: content/ai-getting-started-with-ai.md:1
 #, fuzzy, no-wrap
 msgid "about"
-msgstr "关于"
+msgstr "about"
 
 #. type: Yaml Front Matter Hash Value: link
 #: content/ai-getting-started-with-ai.md:1

--- a/l10n/po/zh_CN/content/ai-overview.md.po
+++ b/l10n/po/zh_CN/content/ai-overview.md.po
@@ -14,7 +14,7 @@ msgstr ""
 #: content/ai-overview.md:1
 #, fuzzy, no-wrap
 msgid "ai-overview"
-msgstr "ai-概述"
+msgstr "ai-overview"
 
 #. type: Yaml Front Matter Hash Value: link
 #. mt: deepl

--- a/l10n/po/zh_CN/content/author.md.po
+++ b/l10n/po/zh_CN/content/author.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: content/author.md:1
 #, fuzzy, no-wrap
 msgid "authors"
-msgstr "作者"
+msgstr "authors"
 
 #. type: Yaml Front Matter Hash Value: paginate collection
 #: content/author.md:1

--- a/l10n/po/zh_CN/content/benefactors.md.po
+++ b/l10n/po/zh_CN/content/benefactors.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: content/benefactors.md:1
 #, fuzzy, no-wrap
 msgid "benefactors"
-msgstr "恩人"
+msgstr "benefactors"
 
 #. type: Yaml Front Matter Hash Value: subtitle
 #: content/benefactors.md:1

--- a/l10n/po/zh_CN/content/blog.md.po
+++ b/l10n/po/zh_CN/content/blog.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: content/blog.md:1
 #, no-wrap
 msgid "blog"
-msgstr "博客"
+msgstr "blog"
 
 #. type: Yaml Front Matter Hash Value: paginate collection
 #: content/blog.md:1

--- a/l10n/po/zh_CN/content/books.md.po
+++ b/l10n/po/zh_CN/content/books.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: content/books.md:1
 #, fuzzy, no-wrap
 msgid "books"
-msgstr "书籍"
+msgstr "books"
 
 #. type: Yaml Front Matter Hash Value: subtitle
 #: content/books.md:1

--- a/l10n/po/zh_CN/content/brand.md.po
+++ b/l10n/po/zh_CN/content/brand.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: content/brand.md:1
 #, fuzzy, no-wrap
 msgid "brand"
-msgstr "品牌"
+msgstr "brand"
 
 #. type: Yaml Front Matter Hash Value: subtitle
 #: content/brand.md:1

--- a/l10n/po/zh_CN/content/components.md.po
+++ b/l10n/po/zh_CN/content/components.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: content/components.md:1
 #, fuzzy, no-wrap
 msgid "components"
-msgstr "组件"
+msgstr "components"
 
 #. type: Yaml Front Matter Hash Value: title
 #: content/components.md:1

--- a/l10n/po/zh_CN/content/container-first.md.po
+++ b/l10n/po/zh_CN/content/container-first.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: content/container-first.md:1
 #, fuzzy, no-wrap
 msgid "container-first"
-msgstr "容器优先"
+msgstr "container-first"
 
 #. type: Yaml Front Matter Hash Value: subtitle
 #: content/container-first.md:1

--- a/l10n/po/zh_CN/content/desktopwallpapers.md.po
+++ b/l10n/po/zh_CN/content/desktopwallpapers.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: content/desktopwallpapers.md:1
 #, fuzzy, no-wrap
 msgid "desktop_wallpaper"
-msgstr "桌面壁纸"
+msgstr "desktop_wallpaper"
 
 #. type: Yaml Front Matter Hash Value: subtitle
 #: content/desktopwallpapers.md:1

--- a/l10n/po/zh_CN/content/developer-joy.md.po
+++ b/l10n/po/zh_CN/content/developer-joy.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: content/developer-joy.md:1
 #, fuzzy, no-wrap
 msgid "developer-joy"
-msgstr "开发者之乐"
+msgstr "developer-joy"
 
 #. type: Yaml Front Matter Hash Value: subtitle
 #: content/developer-joy.md:1

--- a/l10n/po/zh_CN/content/discussion.md.po
+++ b/l10n/po/zh_CN/content/discussion.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: content/discussion.md:1
 #, fuzzy, no-wrap
 msgid "discussion"
-msgstr "讨论"
+msgstr "discussion"
 
 #. type: Yaml Front Matter Hash Value: subtitle
 #: content/discussion.md:1

--- a/l10n/po/zh_CN/content/events.md.po
+++ b/l10n/po/zh_CN/content/events.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: content/events.md:1
 #, fuzzy, no-wrap
 msgid "events"
-msgstr "活动"
+msgstr "events"
 
 #. type: Yaml Front Matter Hash Value: subtitle
 #: content/events.md:1

--- a/l10n/po/zh_CN/content/faq.adoc.po
+++ b/l10n/po/zh_CN/content/faq.adoc.po
@@ -52,13 +52,13 @@ msgid "Extensions have a various degree of maturity when they enter the Quarkus 
 msgstr "扩展在进入Quarkus生态系统时具有不同程度的成熟度。状态提供了你可以依赖的期望。"
 
 msgid "*Stable*: backward compatibility and presence in the ecosystem are taken very seriously. An application can safely rely on these extensions. Extensions not marked as preview or experimental (the majority) are stable."
-msgstr "*Stable*: 向后兼容性和在生态系统中的存在被非常重视。应用程序可以安全地依赖于这些扩展。没有标记为预览或实验的扩展(大多数)是稳定的。\n"
+msgstr "*Stable*: 向后兼容性和在生态系统中的存在被非常重视。应用程序可以安全地依赖于这些扩展。没有标记为预览或实验的扩展(大多数)是稳定的。"
 
 msgid "*Preview*: backward compatibility and presence in the ecosystem is not guaranteed. Specific improvements might require to change configuration or APIs and plans to become _stable_ are under way. Such extensions are in the middle of their maturation process."
-msgstr "*Preview*: 不能保证向后兼容性和在生态系统中的存在。具体的改进可能需要改变配置、API和计划，使之变得 _stable_ 。这些扩展还处于成熟过程的中间阶段。\n"
+msgstr "*Preview*: 不能保证向后兼容性和在生态系统中的存在。具体的改进可能需要改变配置、API和计划，使之变得 _stable_ 。这些扩展还处于成熟过程的中间阶段。"
 
 msgid "*Experimental*: early feedback is requested to mature the idea. There is no guarantee of stability nor long term presence in the platform until the solution matures. Such extensions are at the beginning of their maturation process."
-msgstr "*Experimental*: 尽早反馈，以使想法更加成熟。在解决方案成熟之前，无法保证平台的稳定性或长期存在。这些扩展正处于其成熟过程的开始阶段。\n"
+msgstr "*Experimental*: 尽早反馈，以使想法更加成熟。在解决方案成熟之前，无法保证平台的稳定性或长期存在。这些扩展正处于其成熟过程的开始阶段。"
 
 #. mt: deepl
 #, fuzzy

--- a/l10n/po/zh_CN/content/foundation-faq.md.po
+++ b/l10n/po/zh_CN/content/foundation-faq.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: content/foundation-faq.md:1
 #, fuzzy, no-wrap
 msgid "usage"
-msgstr "用法"
+msgstr "usage"
 
 #. type: Yaml Front Matter Hash Value: link
 #: content/foundation-faq.md:1

--- a/l10n/po/zh_CN/content/foundation.md.po
+++ b/l10n/po/zh_CN/content/foundation.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: content/foundation.md:1
 #, fuzzy, no-wrap
 msgid "usage"
-msgstr "用法"
+msgstr "usage"
 
 #. type: Yaml Front Matter Hash Value: subtitle
 #: content/foundation.md:1

--- a/l10n/po/zh_CN/content/guides/guides.md.po
+++ b/l10n/po/zh_CN/content/guides/guides.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: content/guides/guides.md:1
 #, fuzzy, no-wrap
 msgid "documentation"
-msgstr "文档"
+msgstr "documentation"
 
 #. type: Yaml Front Matter Hash Value: link
 #: content/guides/guides.md:1

--- a/l10n/po/zh_CN/content/guides/kafka.adoc.po
+++ b/l10n/po/zh_CN/content/guides/kafka.adoc.po
@@ -24,13 +24,13 @@ msgid ""
 msgstr "link:https://kafka.apache.org[Apache Kafka] 是一个流行的开源分布式事件流平台。它通常用于高性能数据管道、流式分析、数据集成以及任务关键型应用。类似于消息队列或企业消息平台，它可以允许您："
 
 msgid "*publish* (write) and *subscribe* to (read) streams of events, called _records_."
-msgstr "*发布* (写)以及 *订阅* (读)事件流，称为 _记录_ 。\n"
+msgstr "*发布* (写)以及 *订阅* (读)事件流，称为 _记录_ 。"
 
 msgid "*store* streams of records durably and reliably inside _topics_."
-msgstr "在 _topic_ 内持久而可靠地 *存储* 流式记录。\n"
+msgstr "在 _topic_ 内持久而可靠地 *存储* 流式记录。"
 
 msgid "*process* streams of records as they occur or retrospectively."
-msgstr "对流式记录进行起始或回溯*处理*。\n"
+msgstr "对流式记录进行起始或回溯*处理*。"
 
 msgid "And all this functionality is provided in a distributed, highly scalable, elastic, fault-tolerant, and secure manner."
 msgstr "而所有这些功能都是以分布式、高可扩展性、弹性、容错以及安全的方式提供的。"
@@ -344,19 +344,19 @@ msgid "The record written on the dead letter queue contains a set of additional 
 msgstr "所有写入dead letter queue中的记录将包含一组关于原始记录的附加headers："
 
 msgid "*dead-letter-reason*: the reason of the failure"
-msgstr "*dead-letter-reason* ：失败原因\n"
+msgstr "*dead-letter-reason* ：失败原因"
 
 msgid "*dead-letter-cause*: the cause of the failure if any"
-msgstr "*dead-letter-cause* ：失败的起因(如果有)。\n"
+msgstr "*dead-letter-cause* ：失败的起因(如果有)。"
 
 msgid "*dead-letter-topic*: the original topic of the record"
-msgstr "*dead-letter-topic* ：失败记录的原始topic\n"
+msgstr "*dead-letter-topic* ：失败记录的原始topic"
 
 msgid "*dead-letter-partition*: the original partition of the record (integer mapped to String)"
-msgstr "*dead-letter-partition* ：失败记录的原始分区(integer映射为String)\n"
+msgstr "*dead-letter-partition* ：失败记录的原始分区(integer映射为String)"
 
 msgid "*dead-letter-offset*: the original offset of the record (long mapped to String)"
-msgstr "*dead-letter-offset* ：失败记录的原始偏移量(long映射为String)\n"
+msgstr "*dead-letter-offset* ：失败记录的原始偏移量(long映射为String)"
 
 #, fuzzy
 msgid ""
@@ -424,7 +424,7 @@ msgid "Let's explore briefly different producer/consumer patterns and how to imp
 msgstr "让我们简单展示一下不同的生产者/消费者模式以及如何使用Quarkus来实现它们："
 
 msgid "*Single consumer thread inside a consumer group*"
-msgstr "*消费者组内使用单一消费者线程*\n"
+msgstr "*消费者组内使用单一消费者线程*"
 
 msgid ""
 "This is the default behavior of an application subscribing to a Kafka topic: Each Kafka connector will create a single consumer thread and place it inside a single consumer group.\n"
@@ -433,7 +433,7 @@ msgid ""
 msgstr "这是一个应用程序订阅Kafka topic的默认方式：每个Kafka Connector将创建一个独立的消费者线程，并将其置于一个单独的消费者组内。消费者组id默认为 `quarkus.application.name` 所设定的应用程序名称。它也可以使用 `kafka.group.id` 来设置。"
 
 msgid "*Multiple consumer threads inside a consumer group*"
-msgstr "*一个消费者组内使用多个消费者线程* \n"
+msgstr "*一个消费者组内使用多个消费者线程* "
 
 #, fuzzy
 msgid ""
@@ -453,7 +453,7 @@ msgid ""
 msgstr "link:https://smallrye.io/smallrye-reactive-messaging/latest/concepts/incoming-concurrency/[concurrency 属性提供了一种] 与连接器无关的非阻塞并发通道实现方式，并取代了原有的 Kafka 连接器专用的 `partitions` 属性。因此， `partitions` 属性已被废弃，并将在未来的版本中移除。"
 
 msgid "*Multiple consumer applications inside a consumer group*"
-msgstr "*一个消费者组内有多个消费者应用程序* \n"
+msgstr "*一个消费者组内有多个消费者应用程序* "
 
 msgid ""
 "Similar to the previous example, multiple instances of an application can subscribe to a single consumer group, configured via `mp.messaging.incoming.$channel.group.id` property, or left default to the application name.\n"
@@ -461,7 +461,7 @@ msgid ""
 msgstr "与前面的例子类似，一个应用程序的多个实例可以订阅同一个消费者组。这种方式可以通过 `mp.messaging.incoming.$channel.group.id` 进行配置，或默认为应用程序的名称。这种方式会在应用程序实例之间分配topic的分区。"
 
 msgid "*Pub/Sub: Multiple consumer groups subscribed to a topic*"
-msgstr "*发布/订阅：多个消费者群体订阅同一个topic* \n"
+msgstr "*发布/订阅：多个消费者群体订阅同一个topic* "
 
 msgid ""
 "Lastly different applications can subscribe independently to same topics using different *consumer group ids*.\n"

--- a/l10n/po/zh_CN/content/guides/vertx.adoc.po
+++ b/l10n/po/zh_CN/content/guides/vertx.adoc.po
@@ -285,7 +285,7 @@ msgstr ""
 "在终端中，运行以下命令:"
 
 msgid "You should get the expected `Hello bob` message back."
-msgstr "你应该会收到预期的 `Hello bob` 消息。\n"
+msgstr "你应该会收到预期的 `Hello bob` 消息。"
 
 msgid "Using Vert.x Clients"
 msgstr "使用Vert.x客户端"
@@ -349,10 +349,10 @@ msgid "Extract the `langlinks` array from the response."
 msgstr "从响应中提取 `langlinks` 数组。"
 
 msgid "Then, invoke the endpoint using:"
-msgstr "接着，使用以下命令请求该端点:\n"
+msgstr "接着，使用以下命令请求该端点:"
 
 msgid "The response indicates that, in addition to the English page, there are a German and a French page about Quarkus on wikipedia."
-msgstr "该响应表明，除了英文页面，维基百科上还有关于 Quarkus 的德文和法文页面。\n"
+msgstr "该响应表明，除了英文页面，维基百科上还有关于 Quarkus 的德文和法文页面。"
 
 #, fuzzy
 msgid "Executing Asynchronous Code From a Blocking Thread"

--- a/l10n/po/zh_CN/content/index.md.po
+++ b/l10n/po/zh_CN/content/index.md.po
@@ -19,7 +19,7 @@ msgstr "Quarkus：超音速亚原子 Java"
 #: content/index.md:1
 #, fuzzy, no-wrap
 msgid "index"
-msgstr "索引"
+msgstr "index"
 
 #. type: Yaml Front Matter Hash Value: simple-name
 #: content/index.md:1

--- a/l10n/po/zh_CN/content/insights.md.po
+++ b/l10n/po/zh_CN/content/insights.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: content/insights.md:1
 #, fuzzy, no-wrap
 msgid "insights"
-msgstr "见解"
+msgstr "insights"
 
 #. type: Yaml Front Matter Hash Value: subtitle
 #: content/insights.md:1

--- a/l10n/po/zh_CN/content/newsletter.md.po
+++ b/l10n/po/zh_CN/content/newsletter.md.po
@@ -19,7 +19,7 @@ msgstr "/出版物"
 #: content/newsletter.md:1
 #, fuzzy, no-wrap
 msgid "newsletter"
-msgstr "通讯"
+msgstr "newsletter"
 
 #. type: Yaml Front Matter Hash Value: subtitle
 #: content/newsletter.md:1

--- a/l10n/po/zh_CN/content/performance.md.po
+++ b/l10n/po/zh_CN/content/performance.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: content/performance.md:1
 #, fuzzy, no-wrap
 msgid "performance"
-msgstr "性能测量.adoc"
+msgstr "performance"
 
 #. type: Yaml Front Matter Hash Value: subtitle
 #: content/performance.md:1

--- a/l10n/po/zh_CN/content/posts/2023-11-02-mandrel-23-0-image-size-increase.md.po
+++ b/l10n/po/zh_CN/content/posts/2023-11-02-mandrel-23-0-image-size-increase.md.po
@@ -25,7 +25,7 @@ msgstr "2023-11-02"
 #: content/posts/2023-11-02-mandrel-23-0-image-size-increase.md:1
 #, fuzzy, no-wrap
 msgid "post"
-msgstr "邮寄"
+msgstr "post"
 
 #. type: Yaml Front Matter Hash Value: synopsis
 #: content/posts/2023-11-02-mandrel-23-0-image-size-increase.md:1

--- a/l10n/po/zh_CN/content/posts/2023-11-08-mandrel-23-1-image-size-increase.md.po
+++ b/l10n/po/zh_CN/content/posts/2023-11-08-mandrel-23-1-image-size-increase.md.po
@@ -25,7 +25,7 @@ msgstr "2023-11-08"
 #: content/posts/2023-11-08-mandrel-23-1-image-size-increase.md:1
 #, fuzzy, no-wrap
 msgid "post"
-msgstr "邮寄"
+msgstr "post"
 
 #. type: Yaml Front Matter Hash Value: synopsis
 #: content/posts/2023-11-08-mandrel-23-1-image-size-increase.md:1

--- a/l10n/po/zh_CN/content/releases.md.po
+++ b/l10n/po/zh_CN/content/releases.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: content/releases.md:1
 #, fuzzy, no-wrap
 msgid "releases"
-msgstr "发布"
+msgstr "releases"
 
 #. type: Yaml Front Matter Hash Value: subtitle
 #: content/releases.md:1

--- a/l10n/po/zh_CN/content/sitemap.md.po
+++ b/l10n/po/zh_CN/content/sitemap.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: content/sitemap.md:1
 #, fuzzy, no-wrap
 msgid "sitemap"
-msgstr "网站地图"
+msgstr "sitemap"
 
 #. type: Yaml Front Matter Hash Value: subtitle
 #: content/sitemap.md:1

--- a/l10n/po/zh_CN/content/socials.md.po
+++ b/l10n/po/zh_CN/content/socials.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: content/socials.md:1
 #, fuzzy, no-wrap
 msgid "socials"
-msgstr "社交活动"
+msgstr "socials"
 
 #. type: Yaml Front Matter Hash Value: subtitle
 #: content/socials.md:1

--- a/l10n/po/zh_CN/content/spring.md.po
+++ b/l10n/po/zh_CN/content/spring.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: content/spring.md:1
 #, fuzzy, no-wrap
 msgid "spring"
-msgstr "春天"
+msgstr "spring"
 
 #. type: Yaml Front Matter Hash Value: subtitle
 #: content/spring.md:1

--- a/l10n/po/zh_CN/content/standards.md.po
+++ b/l10n/po/zh_CN/content/standards.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: content/standards.md:1
 #, fuzzy, no-wrap
 msgid "standards"
-msgstr "标准"
+msgstr "standards"
 
 #. type: Yaml Front Matter Hash Value: subtitle
 #: content/standards.md:1

--- a/l10n/po/zh_CN/content/stickers.md.po
+++ b/l10n/po/zh_CN/content/stickers.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: content/stickers.md:1
 #, fuzzy, no-wrap
 msgid "stickers"
-msgstr "贴纸"
+msgstr "stickers"
 
 #. type: Yaml Front Matter Hash Value: title
 #: content/stickers.md:1

--- a/l10n/po/zh_CN/content/support.md.po
+++ b/l10n/po/zh_CN/content/support.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: content/support.md:1
 #, fuzzy, no-wrap
 msgid "support"
-msgstr "支持"
+msgstr "support"
 
 #. type: Yaml Front Matter Hash Value: title
 #: content/support.md:1

--- a/l10n/po/zh_CN/content/usage.md.po
+++ b/l10n/po/zh_CN/content/usage.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: content/usage.md:1
 #, fuzzy, no-wrap
 msgid "usage"
-msgstr "用法"
+msgstr "usage"
 
 #. type: Yaml Front Matter Hash Value: subtitle
 #: content/usage.md:1

--- a/l10n/po/zh_CN/content/usage_policy.md.po
+++ b/l10n/po/zh_CN/content/usage_policy.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: content/usage_policy.md:1
 #, fuzzy, no-wrap
 msgid "usagepolicy"
-msgstr "使用政策"
+msgstr "usagepolicy"
 
 #. type: Yaml Front Matter Hash Value: link
 #: content/usage_policy.md:1

--- a/l10n/po/zh_CN/content/userstories.md.po
+++ b/l10n/po/zh_CN/content/userstories.md.po
@@ -14,7 +14,7 @@ msgstr ""
 #: content/userstories.md:1
 #, fuzzy, no-wrap
 msgid "userstories"
-msgstr "用户故事"
+msgstr "userstories"
 
 #. type: Yaml Front Matter Hash Value: subtitle
 #. mt: deepl

--- a/l10n/po/zh_CN/content/versions/2.13/guides/guides.md.po
+++ b/l10n/po/zh_CN/content/versions/2.13/guides/guides.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: content/versions/2.13/guides/guides.md:1
 #, fuzzy, no-wrap
 msgid "documentation"
-msgstr "文档"
+msgstr "documentation"
 
 #. type: Yaml Front Matter Hash Value: link
 #: content/versions/2.13/guides/guides.md:1

--- a/l10n/po/zh_CN/content/versions/2.13/guides/kafka.adoc.po
+++ b/l10n/po/zh_CN/content/versions/2.13/guides/kafka.adoc.po
@@ -22,13 +22,13 @@ msgid ""
 msgstr "link:https://kafka.apache.org[Apache Kafka] 是一个流行的开源分布式事件流平台。它通常用于高性能数据管道、流式分析、数据集成以及任务关键型应用。类似于消息队列或企业消息平台，它可以允许您："
 
 msgid "*publish* (write) and *subscribe* to (read) streams of events, called _records_."
-msgstr "*发布* (写)以及 *订阅* (读)事件流，称为 _记录_ 。\n"
+msgstr "*发布* (写)以及 *订阅* (读)事件流，称为 _记录_ 。"
 
 msgid "*store* streams of records durably and reliably inside _topics_."
-msgstr "在 _topic_ 内持久而可靠地 *存储* 流式记录。\n"
+msgstr "在 _topic_ 内持久而可靠地 *存储* 流式记录。"
 
 msgid "*process* streams of records as they occur or retrospectively."
-msgstr "对流式记录进行起始或回溯*处理*。\n"
+msgstr "对流式记录进行起始或回溯*处理*。"
 
 msgid "And all this functionality is provided in a distributed, highly scalable, elastic, fault-tolerant, and secure manner."
 msgstr "而所有这些功能都是以分布式、高可扩展性、弹性、容错以及安全的方式提供的。"
@@ -309,19 +309,19 @@ msgid "The record written on the dead letter queue contains a set of additional 
 msgstr "所有写入dead letter queue中的记录将包含一组关于原始记录的附加headers："
 
 msgid "*dead-letter-reason*: the reason of the failure"
-msgstr "*dead-letter-reason* ：失败原因\n"
+msgstr "*dead-letter-reason* ：失败原因"
 
 msgid "*dead-letter-cause*: the cause of the failure if any"
-msgstr "*dead-letter-cause* ：失败的起因(如果有)。\n"
+msgstr "*dead-letter-cause* ：失败的起因(如果有)。"
 
 msgid "*dead-letter-topic*: the original topic of the record"
-msgstr "*dead-letter-topic* ：失败记录的原始topic\n"
+msgstr "*dead-letter-topic* ：失败记录的原始topic"
 
 msgid "*dead-letter-partition*: the original partition of the record (integer mapped to String)"
-msgstr "*dead-letter-partition* ：失败记录的原始分区(integer映射为String)\n"
+msgstr "*dead-letter-partition* ：失败记录的原始分区(integer映射为String)"
 
 msgid "*dead-letter-offset*: the original offset of the record (long mapped to String)"
-msgstr "*dead-letter-offset* ：失败记录的原始偏移量(long映射为String)\n"
+msgstr "*dead-letter-offset* ：失败记录的原始偏移量(long映射为String)"
 
 #, fuzzy
 msgid ""
@@ -378,7 +378,7 @@ msgid "Let's explore briefly different producer/consumer patterns and how to imp
 msgstr "让我们简单展示一下不同的生产者/消费者模式以及如何使用Quarkus来实现它们："
 
 msgid "*Single consumer thread inside a consumer group*"
-msgstr "*消费者组内使用单一消费者线程*\n"
+msgstr "*消费者组内使用单一消费者线程*"
 
 msgid ""
 "This is the default behavior of an application subscribing to a Kafka topic: Each Kafka connector will create a single consumer thread and place it inside a single consumer group.\n"
@@ -387,7 +387,7 @@ msgid ""
 msgstr "这是一个应用程序订阅Kafka topic的默认方式：每个Kafka Connector将创建一个独立的消费者线程，并将其置于一个单独的消费者组内。消费者组id默认为 `quarkus.application.name` 所设定的应用程序名称。它也可以使用 `kafka.group.id` 来设置。"
 
 msgid "*Multiple consumer threads inside a consumer group*"
-msgstr "*一个消费者组内使用多个消费者线程* \n"
+msgstr "*一个消费者组内使用多个消费者线程* "
 
 msgid ""
 "For a given application instance, the number of consumers inside the consumer group can be configured using `mp.messaging.incoming.$channel.partitions` property.\n"
@@ -396,7 +396,7 @@ msgid ""
 msgstr "对于一个给定的应用程序实例，消费者组内的消费者数量可以使用 `mp.messaging.incoming.$channel.partitions` 进行配置。被订阅的topic中的分区将会在所有的消费者线程间进行分配。请注意，如果 `partitions` 值超过topic本身的分区数量，那么某些消费者线程将得不到分区分配。"
 
 msgid "*Multiple consumer applications inside a consumer group*"
-msgstr "*一个消费者组内有多个消费者应用程序* \n"
+msgstr "*一个消费者组内有多个消费者应用程序* "
 
 msgid ""
 "Similar to the previous example, multiple instances of an application can subscribe to a single consumer group, configured via `mp.messaging.incoming.$channel.group.id` property, or left default to the application name.\n"
@@ -404,7 +404,7 @@ msgid ""
 msgstr "与前面的例子类似，一个应用程序的多个实例可以订阅同一个消费者组。这种方式可以通过 `mp.messaging.incoming.$channel.group.id` 进行配置，或默认为应用程序的名称。这种方式会在应用程序实例之间分配topic的分区。"
 
 msgid "*Pub/Sub: Multiple consumer groups subscribed to a topic*"
-msgstr "*发布/订阅：多个消费者群体订阅同一个topic* \n"
+msgstr "*发布/订阅：多个消费者群体订阅同一个topic* "
 
 msgid ""
 "Lastly different applications can subscribe independently to same topics using different *consumer group ids*.\n"

--- a/l10n/po/zh_CN/content/versions/2.13/guides/vertx.adoc.po
+++ b/l10n/po/zh_CN/content/versions/2.13/guides/vertx.adoc.po
@@ -280,7 +280,7 @@ msgstr ""
 "在终端中，运行以下命令:"
 
 msgid "You should get the expected `Hello bob` message back."
-msgstr "你应该会收到预期的 `Hello bob` 消息。\n"
+msgstr "你应该会收到预期的 `Hello bob` 消息。"
 
 msgid "Using Vert.x Clients"
 msgstr "使用Vert.x客户端"
@@ -344,10 +344,10 @@ msgid "Extract the `langlinks` array from the response."
 msgstr "从响应中提取 `langlinks` 数组。"
 
 msgid "Then, invoke the endpoint using:"
-msgstr "接着，使用以下命令请求该端点:\n"
+msgstr "接着，使用以下命令请求该端点:"
 
 msgid "The response indicates that, in addition to the English page, there are a German and a French page about Quarkus on wikipedia."
-msgstr "该响应表明，除了英文页面，维基百科上还有关于 Quarkus 的德文和法文页面。\n"
+msgstr "该响应表明，除了英文页面，维基百科上还有关于 Quarkus 的德文和法文页面。"
 
 msgid "Going further"
 msgstr "进一步探索"

--- a/l10n/po/zh_CN/content/versions/2.16/guides/guides.md.po
+++ b/l10n/po/zh_CN/content/versions/2.16/guides/guides.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: content/versions/2.16/guides/guides.md:1
 #, fuzzy, no-wrap
 msgid "documentation"
-msgstr "文档"
+msgstr "documentation"
 
 #. type: Yaml Front Matter Hash Value: link
 #: content/versions/2.16/guides/guides.md:1

--- a/l10n/po/zh_CN/content/versions/2.16/guides/kafka.adoc.po
+++ b/l10n/po/zh_CN/content/versions/2.16/guides/kafka.adoc.po
@@ -22,13 +22,13 @@ msgid ""
 msgstr "link:https://kafka.apache.org[Apache Kafka] 是一个流行的开源分布式事件流平台。它通常用于高性能数据管道、流式分析、数据集成以及任务关键型应用。类似于消息队列或企业消息平台，它可以允许您："
 
 msgid "*publish* (write) and *subscribe* to (read) streams of events, called _records_."
-msgstr "*发布* (写)以及 *订阅* (读)事件流，称为 _记录_ 。\n"
+msgstr "*发布* (写)以及 *订阅* (读)事件流，称为 _记录_ 。"
 
 msgid "*store* streams of records durably and reliably inside _topics_."
-msgstr "在 _topic_ 内持久而可靠地 *存储* 流式记录。\n"
+msgstr "在 _topic_ 内持久而可靠地 *存储* 流式记录。"
 
 msgid "*process* streams of records as they occur or retrospectively."
-msgstr "对流式记录进行起始或回溯*处理*。\n"
+msgstr "对流式记录进行起始或回溯*处理*。"
 
 msgid "And all this functionality is provided in a distributed, highly scalable, elastic, fault-tolerant, and secure manner."
 msgstr "而所有这些功能都是以分布式、高可扩展性、弹性、容错以及安全的方式提供的。"
@@ -320,19 +320,19 @@ msgid "The record written on the dead letter queue contains a set of additional 
 msgstr "所有写入dead letter queue中的记录将包含一组关于原始记录的附加headers："
 
 msgid "*dead-letter-reason*: the reason of the failure"
-msgstr "*dead-letter-reason* ：失败原因\n"
+msgstr "*dead-letter-reason* ：失败原因"
 
 msgid "*dead-letter-cause*: the cause of the failure if any"
-msgstr "*dead-letter-cause* ：失败的起因(如果有)。\n"
+msgstr "*dead-letter-cause* ：失败的起因(如果有)。"
 
 msgid "*dead-letter-topic*: the original topic of the record"
-msgstr "*dead-letter-topic* ：失败记录的原始topic\n"
+msgstr "*dead-letter-topic* ：失败记录的原始topic"
 
 msgid "*dead-letter-partition*: the original partition of the record (integer mapped to String)"
-msgstr "*dead-letter-partition* ：失败记录的原始分区(integer映射为String)\n"
+msgstr "*dead-letter-partition* ：失败记录的原始分区(integer映射为String)"
 
 msgid "*dead-letter-offset*: the original offset of the record (long mapped to String)"
-msgstr "*dead-letter-offset* ：失败记录的原始偏移量(long映射为String)\n"
+msgstr "*dead-letter-offset* ：失败记录的原始偏移量(long映射为String)"
 
 #, fuzzy
 msgid ""
@@ -389,7 +389,7 @@ msgid "Let's explore briefly different producer/consumer patterns and how to imp
 msgstr "让我们简单展示一下不同的生产者/消费者模式以及如何使用Quarkus来实现它们："
 
 msgid "*Single consumer thread inside a consumer group*"
-msgstr "*消费者组内使用单一消费者线程*\n"
+msgstr "*消费者组内使用单一消费者线程*"
 
 msgid ""
 "This is the default behavior of an application subscribing to a Kafka topic: Each Kafka connector will create a single consumer thread and place it inside a single consumer group.\n"
@@ -398,7 +398,7 @@ msgid ""
 msgstr "这是一个应用程序订阅Kafka topic的默认方式：每个Kafka Connector将创建一个独立的消费者线程，并将其置于一个单独的消费者组内。消费者组id默认为 `quarkus.application.name` 所设定的应用程序名称。它也可以使用 `kafka.group.id` 来设置。"
 
 msgid "*Multiple consumer threads inside a consumer group*"
-msgstr "*一个消费者组内使用多个消费者线程* \n"
+msgstr "*一个消费者组内使用多个消费者线程* "
 
 msgid ""
 "For a given application instance, the number of consumers inside the consumer group can be configured using `mp.messaging.incoming.$channel.partitions` property.\n"
@@ -407,7 +407,7 @@ msgid ""
 msgstr "对于一个给定的应用程序实例，消费者组内的消费者数量可以使用 `mp.messaging.incoming.$channel.partitions` 进行配置。被订阅的topic中的分区将会在所有的消费者线程间进行分配。请注意，如果 `partitions` 值超过topic本身的分区数量，那么某些消费者线程将得不到分区分配。"
 
 msgid "*Multiple consumer applications inside a consumer group*"
-msgstr "*一个消费者组内有多个消费者应用程序* \n"
+msgstr "*一个消费者组内有多个消费者应用程序* "
 
 msgid ""
 "Similar to the previous example, multiple instances of an application can subscribe to a single consumer group, configured via `mp.messaging.incoming.$channel.group.id` property, or left default to the application name.\n"
@@ -415,7 +415,7 @@ msgid ""
 msgstr "与前面的例子类似，一个应用程序的多个实例可以订阅同一个消费者组。这种方式可以通过 `mp.messaging.incoming.$channel.group.id` 进行配置，或默认为应用程序的名称。这种方式会在应用程序实例之间分配topic的分区。"
 
 msgid "*Pub/Sub: Multiple consumer groups subscribed to a topic*"
-msgstr "*发布/订阅：多个消费者群体订阅同一个topic* \n"
+msgstr "*发布/订阅：多个消费者群体订阅同一个topic* "
 
 msgid ""
 "Lastly different applications can subscribe independently to same topics using different *consumer group ids*.\n"

--- a/l10n/po/zh_CN/content/versions/2.16/guides/vertx.adoc.po
+++ b/l10n/po/zh_CN/content/versions/2.16/guides/vertx.adoc.po
@@ -280,7 +280,7 @@ msgstr ""
 "在终端中，运行以下命令:"
 
 msgid "You should get the expected `Hello bob` message back."
-msgstr "你应该会收到预期的 `Hello bob` 消息。\n"
+msgstr "你应该会收到预期的 `Hello bob` 消息。"
 
 msgid "Using Vert.x Clients"
 msgstr "使用Vert.x客户端"
@@ -344,10 +344,10 @@ msgid "Extract the `langlinks` array from the response."
 msgstr "从响应中提取 `langlinks` 数组。"
 
 msgid "Then, invoke the endpoint using:"
-msgstr "接着，使用以下命令请求该端点:\n"
+msgstr "接着，使用以下命令请求该端点:"
 
 msgid "The response indicates that, in addition to the English page, there are a German and a French page about Quarkus on wikipedia."
-msgstr "该响应表明，除了英文页面，维基百科上还有关于 Quarkus 的德文和法文页面。\n"
+msgstr "该响应表明，除了英文页面，维基百科上还有关于 Quarkus 的德文和法文页面。"
 
 msgid "Going further"
 msgstr "进一步探索"

--- a/l10n/po/zh_CN/content/versions/3.15/guides/guides.md.po
+++ b/l10n/po/zh_CN/content/versions/3.15/guides/guides.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: content/versions/3.15/guides/guides.md:1
 #, fuzzy, no-wrap
 msgid "documentation"
-msgstr "文档"
+msgstr "documentation"
 
 #. type: Yaml Front Matter Hash Value: link
 #: content/versions/3.15/guides/guides.md:1

--- a/l10n/po/zh_CN/content/versions/3.15/guides/kafka.adoc.po
+++ b/l10n/po/zh_CN/content/versions/3.15/guides/kafka.adoc.po
@@ -23,13 +23,13 @@ msgid ""
 msgstr "link:https://kafka.apache.org[Apache Kafka] 是一个流行的开源分布式事件流平台。它通常用于高性能数据管道、流式分析、数据集成以及任务关键型应用。类似于消息队列或企业消息平台，它可以允许您："
 
 msgid "*publish* (write) and *subscribe* to (read) streams of events, called _records_."
-msgstr "*发布* (写)以及 *订阅* (读)事件流，称为 _记录_ 。\n"
+msgstr "*发布* (写)以及 *订阅* (读)事件流，称为 _记录_ 。"
 
 msgid "*store* streams of records durably and reliably inside _topics_."
-msgstr "在 _topic_ 内持久而可靠地 *存储* 流式记录。\n"
+msgstr "在 _topic_ 内持久而可靠地 *存储* 流式记录。"
 
 msgid "*process* streams of records as they occur or retrospectively."
-msgstr "对流式记录进行起始或回溯*处理*。\n"
+msgstr "对流式记录进行起始或回溯*处理*。"
 
 msgid "And all this functionality is provided in a distributed, highly scalable, elastic, fault-tolerant, and secure manner."
 msgstr "而所有这些功能都是以分布式、高可扩展性、弹性、容错以及安全的方式提供的。"
@@ -338,19 +338,19 @@ msgid "The record written on the dead letter queue contains a set of additional 
 msgstr "所有写入dead letter queue中的记录将包含一组关于原始记录的附加headers："
 
 msgid "*dead-letter-reason*: the reason of the failure"
-msgstr "*dead-letter-reason* ：失败原因\n"
+msgstr "*dead-letter-reason* ：失败原因"
 
 msgid "*dead-letter-cause*: the cause of the failure if any"
-msgstr "*dead-letter-cause* ：失败的起因(如果有)。\n"
+msgstr "*dead-letter-cause* ：失败的起因(如果有)。"
 
 msgid "*dead-letter-topic*: the original topic of the record"
-msgstr "*dead-letter-topic* ：失败记录的原始topic\n"
+msgstr "*dead-letter-topic* ：失败记录的原始topic"
 
 msgid "*dead-letter-partition*: the original partition of the record (integer mapped to String)"
-msgstr "*dead-letter-partition* ：失败记录的原始分区(integer映射为String)\n"
+msgstr "*dead-letter-partition* ：失败记录的原始分区(integer映射为String)"
 
 msgid "*dead-letter-offset*: the original offset of the record (long mapped to String)"
-msgstr "*dead-letter-offset* ：失败记录的原始偏移量(long映射为String)\n"
+msgstr "*dead-letter-offset* ：失败记录的原始偏移量(long映射为String)"
 
 #, fuzzy
 msgid ""
@@ -418,7 +418,7 @@ msgid "Let's explore briefly different producer/consumer patterns and how to imp
 msgstr "让我们简单展示一下不同的生产者/消费者模式以及如何使用Quarkus来实现它们："
 
 msgid "*Single consumer thread inside a consumer group*"
-msgstr "*消费者组内使用单一消费者线程*\n"
+msgstr "*消费者组内使用单一消费者线程*"
 
 msgid ""
 "This is the default behavior of an application subscribing to a Kafka topic: Each Kafka connector will create a single consumer thread and place it inside a single consumer group.\n"
@@ -427,7 +427,7 @@ msgid ""
 msgstr "这是一个应用程序订阅Kafka topic的默认方式：每个Kafka Connector将创建一个独立的消费者线程，并将其置于一个单独的消费者组内。消费者组id默认为 `quarkus.application.name` 所设定的应用程序名称。它也可以使用 `kafka.group.id` 来设置。"
 
 msgid "*Multiple consumer threads inside a consumer group*"
-msgstr "*一个消费者组内使用多个消费者线程* \n"
+msgstr "*一个消费者组内使用多个消费者线程* "
 
 #, fuzzy
 msgid ""
@@ -447,7 +447,7 @@ msgid ""
 msgstr "link:https://smallrye.io/smallrye-reactive-messaging/latest/concepts/incoming-concurrency/[concurrency 属性提供了一种] 与连接器无关的非阻塞并发通道实现方式，并取代了原有的 Kafka 连接器专用的 `partitions` 属性。因此， `partitions` 属性已被废弃，并将在未来的版本中移除。"
 
 msgid "*Multiple consumer applications inside a consumer group*"
-msgstr "*一个消费者组内有多个消费者应用程序* \n"
+msgstr "*一个消费者组内有多个消费者应用程序* "
 
 msgid ""
 "Similar to the previous example, multiple instances of an application can subscribe to a single consumer group, configured via `mp.messaging.incoming.$channel.group.id` property, or left default to the application name.\n"
@@ -455,7 +455,7 @@ msgid ""
 msgstr "与前面的例子类似，一个应用程序的多个实例可以订阅同一个消费者组。这种方式可以通过 `mp.messaging.incoming.$channel.group.id` 进行配置，或默认为应用程序的名称。这种方式会在应用程序实例之间分配topic的分区。"
 
 msgid "*Pub/Sub: Multiple consumer groups subscribed to a topic*"
-msgstr "*发布/订阅：多个消费者群体订阅同一个topic* \n"
+msgstr "*发布/订阅：多个消费者群体订阅同一个topic* "
 
 msgid ""
 "Lastly different applications can subscribe independently to same topics using different *consumer group ids*.\n"

--- a/l10n/po/zh_CN/content/versions/3.15/guides/vertx.adoc.po
+++ b/l10n/po/zh_CN/content/versions/3.15/guides/vertx.adoc.po
@@ -284,7 +284,7 @@ msgstr ""
 "在终端中，运行以下命令:"
 
 msgid "You should get the expected `Hello bob` message back."
-msgstr "你应该会收到预期的 `Hello bob` 消息。\n"
+msgstr "你应该会收到预期的 `Hello bob` 消息。"
 
 msgid "Using Vert.x Clients"
 msgstr "使用Vert.x客户端"
@@ -348,10 +348,10 @@ msgid "Extract the `langlinks` array from the response."
 msgstr "从响应中提取 `langlinks` 数组。"
 
 msgid "Then, invoke the endpoint using:"
-msgstr "接着，使用以下命令请求该端点:\n"
+msgstr "接着，使用以下命令请求该端点:"
 
 msgid "The response indicates that, in addition to the English page, there are a German and a French page about Quarkus on wikipedia."
-msgstr "该响应表明，除了英文页面，维基百科上还有关于 Quarkus 的德文和法文页面。\n"
+msgstr "该响应表明，除了英文页面，维基百科上还有关于 Quarkus 的德文和法文页面。"
 
 #, fuzzy
 msgid "Executing Asynchronous Code From a Blocking Thread"

--- a/l10n/po/zh_CN/content/versions/3.2/guides/guides.md.po
+++ b/l10n/po/zh_CN/content/versions/3.2/guides/guides.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: content/versions/3.2/guides/guides.md:1
 #, fuzzy, no-wrap
 msgid "documentation"
-msgstr "文档"
+msgstr "documentation"
 
 #. type: Yaml Front Matter Hash Value: link
 #: content/versions/3.2/guides/guides.md:1

--- a/l10n/po/zh_CN/content/versions/3.2/guides/kafka.adoc.po
+++ b/l10n/po/zh_CN/content/versions/3.2/guides/kafka.adoc.po
@@ -22,13 +22,13 @@ msgid ""
 msgstr "link:https://kafka.apache.org[Apache Kafka] 是一个流行的开源分布式事件流平台。它通常用于高性能数据管道、流式分析、数据集成以及任务关键型应用。类似于消息队列或企业消息平台，它可以允许您："
 
 msgid "*publish* (write) and *subscribe* to (read) streams of events, called _records_."
-msgstr "*发布* (写)以及 *订阅* (读)事件流，称为 _记录_ 。\n"
+msgstr "*发布* (写)以及 *订阅* (读)事件流，称为 _记录_ 。"
 
 msgid "*store* streams of records durably and reliably inside _topics_."
-msgstr "在 _topic_ 内持久而可靠地 *存储* 流式记录。\n"
+msgstr "在 _topic_ 内持久而可靠地 *存储* 流式记录。"
 
 msgid "*process* streams of records as they occur or retrospectively."
-msgstr "对流式记录进行起始或回溯*处理*。\n"
+msgstr "对流式记录进行起始或回溯*处理*。"
 
 msgid "And all this functionality is provided in a distributed, highly scalable, elastic, fault-tolerant, and secure manner."
 msgstr "而所有这些功能都是以分布式、高可扩展性、弹性、容错以及安全的方式提供的。"
@@ -324,19 +324,19 @@ msgid "The record written on the dead letter queue contains a set of additional 
 msgstr "所有写入dead letter queue中的记录将包含一组关于原始记录的附加headers："
 
 msgid "*dead-letter-reason*: the reason of the failure"
-msgstr "*dead-letter-reason* ：失败原因\n"
+msgstr "*dead-letter-reason* ：失败原因"
 
 msgid "*dead-letter-cause*: the cause of the failure if any"
-msgstr "*dead-letter-cause* ：失败的起因(如果有)。\n"
+msgstr "*dead-letter-cause* ：失败的起因(如果有)。"
 
 msgid "*dead-letter-topic*: the original topic of the record"
-msgstr "*dead-letter-topic* ：失败记录的原始topic\n"
+msgstr "*dead-letter-topic* ：失败记录的原始topic"
 
 msgid "*dead-letter-partition*: the original partition of the record (integer mapped to String)"
-msgstr "*dead-letter-partition* ：失败记录的原始分区(integer映射为String)\n"
+msgstr "*dead-letter-partition* ：失败记录的原始分区(integer映射为String)"
 
 msgid "*dead-letter-offset*: the original offset of the record (long mapped to String)"
-msgstr "*dead-letter-offset* ：失败记录的原始偏移量(long映射为String)\n"
+msgstr "*dead-letter-offset* ：失败记录的原始偏移量(long映射为String)"
 
 #, fuzzy
 msgid ""
@@ -393,7 +393,7 @@ msgid "Let's explore briefly different producer/consumer patterns and how to imp
 msgstr "让我们简单展示一下不同的生产者/消费者模式以及如何使用Quarkus来实现它们："
 
 msgid "*Single consumer thread inside a consumer group*"
-msgstr "*消费者组内使用单一消费者线程*\n"
+msgstr "*消费者组内使用单一消费者线程*"
 
 msgid ""
 "This is the default behavior of an application subscribing to a Kafka topic: Each Kafka connector will create a single consumer thread and place it inside a single consumer group.\n"
@@ -402,7 +402,7 @@ msgid ""
 msgstr "这是一个应用程序订阅Kafka topic的默认方式：每个Kafka Connector将创建一个独立的消费者线程，并将其置于一个单独的消费者组内。消费者组id默认为 `quarkus.application.name` 所设定的应用程序名称。它也可以使用 `kafka.group.id` 来设置。"
 
 msgid "*Multiple consumer threads inside a consumer group*"
-msgstr "*一个消费者组内使用多个消费者线程* \n"
+msgstr "*一个消费者组内使用多个消费者线程* "
 
 msgid ""
 "For a given application instance, the number of consumers inside the consumer group can be configured using `mp.messaging.incoming.$channel.partitions` property.\n"
@@ -411,7 +411,7 @@ msgid ""
 msgstr "对于一个给定的应用程序实例，消费者组内的消费者数量可以使用 `mp.messaging.incoming.$channel.partitions` 进行配置。被订阅的topic中的分区将会在所有的消费者线程间进行分配。请注意，如果 `partitions` 值超过topic本身的分区数量，那么某些消费者线程将得不到分区分配。"
 
 msgid "*Multiple consumer applications inside a consumer group*"
-msgstr "*一个消费者组内有多个消费者应用程序* \n"
+msgstr "*一个消费者组内有多个消费者应用程序* "
 
 msgid ""
 "Similar to the previous example, multiple instances of an application can subscribe to a single consumer group, configured via `mp.messaging.incoming.$channel.group.id` property, or left default to the application name.\n"
@@ -419,7 +419,7 @@ msgid ""
 msgstr "与前面的例子类似，一个应用程序的多个实例可以订阅同一个消费者组。这种方式可以通过 `mp.messaging.incoming.$channel.group.id` 进行配置，或默认为应用程序的名称。这种方式会在应用程序实例之间分配topic的分区。"
 
 msgid "*Pub/Sub: Multiple consumer groups subscribed to a topic*"
-msgstr "*发布/订阅：多个消费者群体订阅同一个topic* \n"
+msgstr "*发布/订阅：多个消费者群体订阅同一个topic* "
 
 msgid ""
 "Lastly different applications can subscribe independently to same topics using different *consumer group ids*.\n"

--- a/l10n/po/zh_CN/content/versions/3.2/guides/vertx.adoc.po
+++ b/l10n/po/zh_CN/content/versions/3.2/guides/vertx.adoc.po
@@ -282,7 +282,7 @@ msgstr ""
 "在终端中，运行以下命令:"
 
 msgid "You should get the expected `Hello bob` message back."
-msgstr "你应该会收到预期的 `Hello bob` 消息。\n"
+msgstr "你应该会收到预期的 `Hello bob` 消息。"
 
 msgid "Using Vert.x Clients"
 msgstr "使用Vert.x客户端"
@@ -346,10 +346,10 @@ msgid "Extract the `langlinks` array from the response."
 msgstr "从响应中提取 `langlinks` 数组。"
 
 msgid "Then, invoke the endpoint using:"
-msgstr "接着，使用以下命令请求该端点:\n"
+msgstr "接着，使用以下命令请求该端点:"
 
 msgid "The response indicates that, in addition to the English page, there are a German and a French page about Quarkus on wikipedia."
-msgstr "该响应表明，除了英文页面，维基百科上还有关于 Quarkus 的德文和法文页面。\n"
+msgstr "该响应表明，除了英文页面，维基百科上还有关于 Quarkus 的德文和法文页面。"
 
 #, fuzzy
 msgid "Executing Asynchronous Code From a Blocking Thread"

--- a/l10n/po/zh_CN/content/versions/3.20/guides/guides.md.po
+++ b/l10n/po/zh_CN/content/versions/3.20/guides/guides.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: content/versions/3.20/guides/guides.md:1
 #, fuzzy, no-wrap
 msgid "documentation"
-msgstr "文档"
+msgstr "documentation"
 
 #. type: Yaml Front Matter Hash Value: link
 #: content/versions/3.20/guides/guides.md:1

--- a/l10n/po/zh_CN/content/versions/3.20/guides/kafka.adoc.po
+++ b/l10n/po/zh_CN/content/versions/3.20/guides/kafka.adoc.po
@@ -23,13 +23,13 @@ msgid ""
 msgstr "link:https://kafka.apache.org[Apache Kafka] 是一个流行的开源分布式事件流平台。它通常用于高性能数据管道、流式分析、数据集成以及任务关键型应用。类似于消息队列或企业消息平台，它可以允许您："
 
 msgid "*publish* (write) and *subscribe* to (read) streams of events, called _records_."
-msgstr "*发布* (写)以及 *订阅* (读)事件流，称为 _记录_ 。\n"
+msgstr "*发布* (写)以及 *订阅* (读)事件流，称为 _记录_ 。"
 
 msgid "*store* streams of records durably and reliably inside _topics_."
-msgstr "在 _topic_ 内持久而可靠地 *存储* 流式记录。\n"
+msgstr "在 _topic_ 内持久而可靠地 *存储* 流式记录。"
 
 msgid "*process* streams of records as they occur or retrospectively."
-msgstr "对流式记录进行起始或回溯*处理*。\n"
+msgstr "对流式记录进行起始或回溯*处理*。"
 
 msgid "And all this functionality is provided in a distributed, highly scalable, elastic, fault-tolerant, and secure manner."
 msgstr "而所有这些功能都是以分布式、高可扩展性、弹性、容错以及安全的方式提供的。"
@@ -338,19 +338,19 @@ msgid "The record written on the dead letter queue contains a set of additional 
 msgstr "所有写入dead letter queue中的记录将包含一组关于原始记录的附加headers："
 
 msgid "*dead-letter-reason*: the reason of the failure"
-msgstr "*dead-letter-reason* ：失败原因\n"
+msgstr "*dead-letter-reason* ：失败原因"
 
 msgid "*dead-letter-cause*: the cause of the failure if any"
-msgstr "*dead-letter-cause* ：失败的起因(如果有)。\n"
+msgstr "*dead-letter-cause* ：失败的起因(如果有)。"
 
 msgid "*dead-letter-topic*: the original topic of the record"
-msgstr "*dead-letter-topic* ：失败记录的原始topic\n"
+msgstr "*dead-letter-topic* ：失败记录的原始topic"
 
 msgid "*dead-letter-partition*: the original partition of the record (integer mapped to String)"
-msgstr "*dead-letter-partition* ：失败记录的原始分区(integer映射为String)\n"
+msgstr "*dead-letter-partition* ：失败记录的原始分区(integer映射为String)"
 
 msgid "*dead-letter-offset*: the original offset of the record (long mapped to String)"
-msgstr "*dead-letter-offset* ：失败记录的原始偏移量(long映射为String)\n"
+msgstr "*dead-letter-offset* ：失败记录的原始偏移量(long映射为String)"
 
 #, fuzzy
 msgid ""
@@ -418,7 +418,7 @@ msgid "Let's explore briefly different producer/consumer patterns and how to imp
 msgstr "让我们简单展示一下不同的生产者/消费者模式以及如何使用Quarkus来实现它们："
 
 msgid "*Single consumer thread inside a consumer group*"
-msgstr "*消费者组内使用单一消费者线程*\n"
+msgstr "*消费者组内使用单一消费者线程*"
 
 msgid ""
 "This is the default behavior of an application subscribing to a Kafka topic: Each Kafka connector will create a single consumer thread and place it inside a single consumer group.\n"
@@ -427,7 +427,7 @@ msgid ""
 msgstr "这是一个应用程序订阅Kafka topic的默认方式：每个Kafka Connector将创建一个独立的消费者线程，并将其置于一个单独的消费者组内。消费者组id默认为 `quarkus.application.name` 所设定的应用程序名称。它也可以使用 `kafka.group.id` 来设置。"
 
 msgid "*Multiple consumer threads inside a consumer group*"
-msgstr "*一个消费者组内使用多个消费者线程* \n"
+msgstr "*一个消费者组内使用多个消费者线程* "
 
 #, fuzzy
 msgid ""
@@ -447,7 +447,7 @@ msgid ""
 msgstr "link:https://smallrye.io/smallrye-reactive-messaging/latest/concepts/incoming-concurrency/[concurrency 属性提供了一种] 与连接器无关的非阻塞并发通道实现方式，并取代了原有的 Kafka 连接器专用的 `partitions` 属性。因此， `partitions` 属性已被废弃，并将在未来的版本中移除。"
 
 msgid "*Multiple consumer applications inside a consumer group*"
-msgstr "*一个消费者组内有多个消费者应用程序* \n"
+msgstr "*一个消费者组内有多个消费者应用程序* "
 
 msgid ""
 "Similar to the previous example, multiple instances of an application can subscribe to a single consumer group, configured via `mp.messaging.incoming.$channel.group.id` property, or left default to the application name.\n"
@@ -455,7 +455,7 @@ msgid ""
 msgstr "与前面的例子类似，一个应用程序的多个实例可以订阅同一个消费者组。这种方式可以通过 `mp.messaging.incoming.$channel.group.id` 进行配置，或默认为应用程序的名称。这种方式会在应用程序实例之间分配topic的分区。"
 
 msgid "*Pub/Sub: Multiple consumer groups subscribed to a topic*"
-msgstr "*发布/订阅：多个消费者群体订阅同一个topic* \n"
+msgstr "*发布/订阅：多个消费者群体订阅同一个topic* "
 
 msgid ""
 "Lastly different applications can subscribe independently to same topics using different *consumer group ids*.\n"

--- a/l10n/po/zh_CN/content/versions/3.20/guides/vertx.adoc.po
+++ b/l10n/po/zh_CN/content/versions/3.20/guides/vertx.adoc.po
@@ -284,7 +284,7 @@ msgstr ""
 "在终端中，运行以下命令:"
 
 msgid "You should get the expected `Hello bob` message back."
-msgstr "你应该会收到预期的 `Hello bob` 消息。\n"
+msgstr "你应该会收到预期的 `Hello bob` 消息。"
 
 msgid "Using Vert.x Clients"
 msgstr "使用Vert.x客户端"
@@ -348,10 +348,10 @@ msgid "Extract the `langlinks` array from the response."
 msgstr "从响应中提取 `langlinks` 数组。"
 
 msgid "Then, invoke the endpoint using:"
-msgstr "接着，使用以下命令请求该端点:\n"
+msgstr "接着，使用以下命令请求该端点:"
 
 msgid "The response indicates that, in addition to the English page, there are a German and a French page about Quarkus on wikipedia."
-msgstr "该响应表明，除了英文页面，维基百科上还有关于 Quarkus 的德文和法文页面。\n"
+msgstr "该响应表明，除了英文页面，维基百科上还有关于 Quarkus 的德文和法文页面。"
 
 #, fuzzy
 msgid "Executing Asynchronous Code From a Blocking Thread"

--- a/l10n/po/zh_CN/content/versions/3.27/guides/guides.md.po
+++ b/l10n/po/zh_CN/content/versions/3.27/guides/guides.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: content/versions/3.27/guides/guides.md:1
 #, fuzzy, no-wrap
 msgid "documentation"
-msgstr "文档"
+msgstr "documentation"
 
 #. type: Yaml Front Matter Hash Value: link
 #: content/versions/3.27/guides/guides.md:1

--- a/l10n/po/zh_CN/content/versions/3.27/guides/kafka.adoc.po
+++ b/l10n/po/zh_CN/content/versions/3.27/guides/kafka.adoc.po
@@ -23,13 +23,13 @@ msgid ""
 msgstr "link:https://kafka.apache.org[Apache Kafka] 是一个流行的开源分布式事件流平台。它通常用于高性能数据管道、流式分析、数据集成以及任务关键型应用。类似于消息队列或企业消息平台，它可以允许您："
 
 msgid "*publish* (write) and *subscribe* to (read) streams of events, called _records_."
-msgstr "*发布* (写)以及 *订阅* (读)事件流，称为 _记录_ 。\n"
+msgstr "*发布* (写)以及 *订阅* (读)事件流，称为 _记录_ 。"
 
 msgid "*store* streams of records durably and reliably inside _topics_."
-msgstr "在 _topic_ 内持久而可靠地 *存储* 流式记录。\n"
+msgstr "在 _topic_ 内持久而可靠地 *存储* 流式记录。"
 
 msgid "*process* streams of records as they occur or retrospectively."
-msgstr "对流式记录进行起始或回溯*处理*。\n"
+msgstr "对流式记录进行起始或回溯*处理*。"
 
 msgid "And all this functionality is provided in a distributed, highly scalable, elastic, fault-tolerant, and secure manner."
 msgstr "而所有这些功能都是以分布式、高可扩展性、弹性、容错以及安全的方式提供的。"
@@ -338,19 +338,19 @@ msgid "The record written on the dead letter queue contains a set of additional 
 msgstr "所有写入dead letter queue中的记录将包含一组关于原始记录的附加headers："
 
 msgid "*dead-letter-reason*: the reason of the failure"
-msgstr "*dead-letter-reason* ：失败原因\n"
+msgstr "*dead-letter-reason* ：失败原因"
 
 msgid "*dead-letter-cause*: the cause of the failure if any"
-msgstr "*dead-letter-cause* ：失败的起因(如果有)。\n"
+msgstr "*dead-letter-cause* ：失败的起因(如果有)。"
 
 msgid "*dead-letter-topic*: the original topic of the record"
-msgstr "*dead-letter-topic* ：失败记录的原始topic\n"
+msgstr "*dead-letter-topic* ：失败记录的原始topic"
 
 msgid "*dead-letter-partition*: the original partition of the record (integer mapped to String)"
-msgstr "*dead-letter-partition* ：失败记录的原始分区(integer映射为String)\n"
+msgstr "*dead-letter-partition* ：失败记录的原始分区(integer映射为String)"
 
 msgid "*dead-letter-offset*: the original offset of the record (long mapped to String)"
-msgstr "*dead-letter-offset* ：失败记录的原始偏移量(long映射为String)\n"
+msgstr "*dead-letter-offset* ：失败记录的原始偏移量(long映射为String)"
 
 #, fuzzy
 msgid ""
@@ -418,7 +418,7 @@ msgid "Let's explore briefly different producer/consumer patterns and how to imp
 msgstr "让我们简单展示一下不同的生产者/消费者模式以及如何使用Quarkus来实现它们："
 
 msgid "*Single consumer thread inside a consumer group*"
-msgstr "*消费者组内使用单一消费者线程*\n"
+msgstr "*消费者组内使用单一消费者线程*"
 
 msgid ""
 "This is the default behavior of an application subscribing to a Kafka topic: Each Kafka connector will create a single consumer thread and place it inside a single consumer group.\n"
@@ -427,7 +427,7 @@ msgid ""
 msgstr "这是一个应用程序订阅Kafka topic的默认方式：每个Kafka Connector将创建一个独立的消费者线程，并将其置于一个单独的消费者组内。消费者组id默认为 `quarkus.application.name` 所设定的应用程序名称。它也可以使用 `kafka.group.id` 来设置。"
 
 msgid "*Multiple consumer threads inside a consumer group*"
-msgstr "*一个消费者组内使用多个消费者线程* \n"
+msgstr "*一个消费者组内使用多个消费者线程* "
 
 #, fuzzy
 msgid ""
@@ -447,7 +447,7 @@ msgid ""
 msgstr "link:https://smallrye.io/smallrye-reactive-messaging/latest/concepts/incoming-concurrency/[concurrency 属性提供了一种] 与连接器无关的非阻塞并发通道实现方式，并取代了原有的 Kafka 连接器专用的 `partitions` 属性。因此， `partitions` 属性已被废弃，并将在未来的版本中移除。"
 
 msgid "*Multiple consumer applications inside a consumer group*"
-msgstr "*一个消费者组内有多个消费者应用程序* \n"
+msgstr "*一个消费者组内有多个消费者应用程序* "
 
 msgid ""
 "Similar to the previous example, multiple instances of an application can subscribe to a single consumer group, configured via `mp.messaging.incoming.$channel.group.id` property, or left default to the application name.\n"
@@ -455,7 +455,7 @@ msgid ""
 msgstr "与前面的例子类似，一个应用程序的多个实例可以订阅同一个消费者组。这种方式可以通过 `mp.messaging.incoming.$channel.group.id` 进行配置，或默认为应用程序的名称。这种方式会在应用程序实例之间分配topic的分区。"
 
 msgid "*Pub/Sub: Multiple consumer groups subscribed to a topic*"
-msgstr "*发布/订阅：多个消费者群体订阅同一个topic* \n"
+msgstr "*发布/订阅：多个消费者群体订阅同一个topic* "
 
 msgid ""
 "Lastly different applications can subscribe independently to same topics using different *consumer group ids*.\n"

--- a/l10n/po/zh_CN/content/versions/3.27/guides/vertx.adoc.po
+++ b/l10n/po/zh_CN/content/versions/3.27/guides/vertx.adoc.po
@@ -284,7 +284,7 @@ msgstr ""
 "在终端中，运行以下命令:"
 
 msgid "You should get the expected `Hello bob` message back."
-msgstr "你应该会收到预期的 `Hello bob` 消息。\n"
+msgstr "你应该会收到预期的 `Hello bob` 消息。"
 
 msgid "Using Vert.x Clients"
 msgstr "使用Vert.x客户端"
@@ -348,10 +348,10 @@ msgid "Extract the `langlinks` array from the response."
 msgstr "从响应中提取 `langlinks` 数组。"
 
 msgid "Then, invoke the endpoint using:"
-msgstr "接着，使用以下命令请求该端点:\n"
+msgstr "接着，使用以下命令请求该端点:"
 
 msgid "The response indicates that, in addition to the English page, there are a German and a French page about Quarkus on wikipedia."
-msgstr "该响应表明，除了英文页面，维基百科上还有关于 Quarkus 的德文和法文页面。\n"
+msgstr "该响应表明，除了英文页面，维基百科上还有关于 Quarkus 的德文和法文页面。"
 
 #, fuzzy
 msgid "Executing Asynchronous Code From a Blocking Thread"

--- a/l10n/po/zh_CN/content/versions/3.33/guides/guides.md.po
+++ b/l10n/po/zh_CN/content/versions/3.33/guides/guides.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: content/versions/3.33/guides/guides.md:1
 #, fuzzy, no-wrap
 msgid "documentation"
-msgstr "文档"
+msgstr "documentation"
 
 #. type: Yaml Front Matter Hash Value: link
 #: content/versions/3.33/guides/guides.md:1

--- a/l10n/po/zh_CN/content/versions/3.33/guides/kafka.adoc.po
+++ b/l10n/po/zh_CN/content/versions/3.33/guides/kafka.adoc.po
@@ -23,13 +23,13 @@ msgid ""
 msgstr "link:https://kafka.apache.org[Apache Kafka] 是一个流行的开源分布式事件流平台。它通常用于高性能数据管道、流式分析、数据集成以及任务关键型应用。类似于消息队列或企业消息平台，它可以允许您："
 
 msgid "*publish* (write) and *subscribe* to (read) streams of events, called _records_."
-msgstr "*发布* (写)以及 *订阅* (读)事件流，称为 _记录_ 。\n"
+msgstr "*发布* (写)以及 *订阅* (读)事件流，称为 _记录_ 。"
 
 msgid "*store* streams of records durably and reliably inside _topics_."
-msgstr "在 _topic_ 内持久而可靠地 *存储* 流式记录。\n"
+msgstr "在 _topic_ 内持久而可靠地 *存储* 流式记录。"
 
 msgid "*process* streams of records as they occur or retrospectively."
-msgstr "对流式记录进行起始或回溯*处理*。\n"
+msgstr "对流式记录进行起始或回溯*处理*。"
 
 msgid "And all this functionality is provided in a distributed, highly scalable, elastic, fault-tolerant, and secure manner."
 msgstr "而所有这些功能都是以分布式、高可扩展性、弹性、容错以及安全的方式提供的。"
@@ -338,19 +338,19 @@ msgid "The record written on the dead letter queue contains a set of additional 
 msgstr "所有写入dead letter queue中的记录将包含一组关于原始记录的附加headers："
 
 msgid "*dead-letter-reason*: the reason of the failure"
-msgstr "*dead-letter-reason* ：失败原因\n"
+msgstr "*dead-letter-reason* ：失败原因"
 
 msgid "*dead-letter-cause*: the cause of the failure if any"
-msgstr "*dead-letter-cause* ：失败的起因(如果有)。\n"
+msgstr "*dead-letter-cause* ：失败的起因(如果有)。"
 
 msgid "*dead-letter-topic*: the original topic of the record"
-msgstr "*dead-letter-topic* ：失败记录的原始topic\n"
+msgstr "*dead-letter-topic* ：失败记录的原始topic"
 
 msgid "*dead-letter-partition*: the original partition of the record (integer mapped to String)"
-msgstr "*dead-letter-partition* ：失败记录的原始分区(integer映射为String)\n"
+msgstr "*dead-letter-partition* ：失败记录的原始分区(integer映射为String)"
 
 msgid "*dead-letter-offset*: the original offset of the record (long mapped to String)"
-msgstr "*dead-letter-offset* ：失败记录的原始偏移量(long映射为String)\n"
+msgstr "*dead-letter-offset* ：失败记录的原始偏移量(long映射为String)"
 
 #, fuzzy
 msgid ""
@@ -418,7 +418,7 @@ msgid "Let's explore briefly different producer/consumer patterns and how to imp
 msgstr "让我们简单展示一下不同的生产者/消费者模式以及如何使用Quarkus来实现它们："
 
 msgid "*Single consumer thread inside a consumer group*"
-msgstr "*消费者组内使用单一消费者线程*\n"
+msgstr "*消费者组内使用单一消费者线程*"
 
 msgid ""
 "This is the default behavior of an application subscribing to a Kafka topic: Each Kafka connector will create a single consumer thread and place it inside a single consumer group.\n"
@@ -427,7 +427,7 @@ msgid ""
 msgstr "这是一个应用程序订阅Kafka topic的默认方式：每个Kafka Connector将创建一个独立的消费者线程，并将其置于一个单独的消费者组内。消费者组id默认为 `quarkus.application.name` 所设定的应用程序名称。它也可以使用 `kafka.group.id` 来设置。"
 
 msgid "*Multiple consumer threads inside a consumer group*"
-msgstr "*一个消费者组内使用多个消费者线程* \n"
+msgstr "*一个消费者组内使用多个消费者线程* "
 
 #, fuzzy
 msgid ""
@@ -447,7 +447,7 @@ msgid ""
 msgstr "link:https://smallrye.io/smallrye-reactive-messaging/latest/concepts/incoming-concurrency/[concurrency 属性提供了一种] 与连接器无关的非阻塞并发通道实现方式，并取代了原有的 Kafka 连接器专用的 `partitions` 属性。因此， `partitions` 属性已被废弃，并将在未来的版本中移除。"
 
 msgid "*Multiple consumer applications inside a consumer group*"
-msgstr "*一个消费者组内有多个消费者应用程序* \n"
+msgstr "*一个消费者组内有多个消费者应用程序* "
 
 msgid ""
 "Similar to the previous example, multiple instances of an application can subscribe to a single consumer group, configured via `mp.messaging.incoming.$channel.group.id` property, or left default to the application name.\n"
@@ -455,7 +455,7 @@ msgid ""
 msgstr "与前面的例子类似，一个应用程序的多个实例可以订阅同一个消费者组。这种方式可以通过 `mp.messaging.incoming.$channel.group.id` 进行配置，或默认为应用程序的名称。这种方式会在应用程序实例之间分配topic的分区。"
 
 msgid "*Pub/Sub: Multiple consumer groups subscribed to a topic*"
-msgstr "*发布/订阅：多个消费者群体订阅同一个topic* \n"
+msgstr "*发布/订阅：多个消费者群体订阅同一个topic* "
 
 msgid ""
 "Lastly different applications can subscribe independently to same topics using different *consumer group ids*.\n"

--- a/l10n/po/zh_CN/content/versions/3.33/guides/vertx.adoc.po
+++ b/l10n/po/zh_CN/content/versions/3.33/guides/vertx.adoc.po
@@ -284,7 +284,7 @@ msgstr ""
 "在终端中，运行以下命令:"
 
 msgid "You should get the expected `Hello bob` message back."
-msgstr "你应该会收到预期的 `Hello bob` 消息。\n"
+msgstr "你应该会收到预期的 `Hello bob` 消息。"
 
 msgid "Using Vert.x Clients"
 msgstr "使用Vert.x客户端"
@@ -348,10 +348,10 @@ msgid "Extract the `langlinks` array from the response."
 msgstr "从响应中提取 `langlinks` 数组。"
 
 msgid "Then, invoke the endpoint using:"
-msgstr "接着，使用以下命令请求该端点:\n"
+msgstr "接着，使用以下命令请求该端点:"
 
 msgid "The response indicates that, in addition to the English page, there are a German and a French page about Quarkus on wikipedia."
-msgstr "该响应表明，除了英文页面，维基百科上还有关于 Quarkus 的德文和法文页面。\n"
+msgstr "该响应表明，除了英文页面，维基百科上还有关于 Quarkus 的德文和法文页面。"
 
 #, fuzzy
 msgid "Executing Asynchronous Code From a Blocking Thread"

--- a/l10n/po/zh_CN/content/versions/3.34/guides/guides.md.po
+++ b/l10n/po/zh_CN/content/versions/3.34/guides/guides.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: content/versions/3.34/guides/guides.md:1
 #, fuzzy, no-wrap
 msgid "documentation"
-msgstr "文档"
+msgstr "documentation"
 
 #. type: Yaml Front Matter Hash Value: link
 #: content/versions/3.34/guides/guides.md:1

--- a/l10n/po/zh_CN/content/versions/3.34/guides/kafka.adoc.po
+++ b/l10n/po/zh_CN/content/versions/3.34/guides/kafka.adoc.po
@@ -23,13 +23,13 @@ msgid ""
 msgstr "link:https://kafka.apache.org[Apache Kafka] 是一个流行的开源分布式事件流平台。它通常用于高性能数据管道、流式分析、数据集成以及任务关键型应用。类似于消息队列或企业消息平台，它可以允许您："
 
 msgid "*publish* (write) and *subscribe* to (read) streams of events, called _records_."
-msgstr "*发布* (写)以及 *订阅* (读)事件流，称为 _记录_ 。\n"
+msgstr "*发布* (写)以及 *订阅* (读)事件流，称为 _记录_ 。"
 
 msgid "*store* streams of records durably and reliably inside _topics_."
-msgstr "在 _topic_ 内持久而可靠地 *存储* 流式记录。\n"
+msgstr "在 _topic_ 内持久而可靠地 *存储* 流式记录。"
 
 msgid "*process* streams of records as they occur or retrospectively."
-msgstr "对流式记录进行起始或回溯*处理*。\n"
+msgstr "对流式记录进行起始或回溯*处理*。"
 
 msgid "And all this functionality is provided in a distributed, highly scalable, elastic, fault-tolerant, and secure manner."
 msgstr "而所有这些功能都是以分布式、高可扩展性、弹性、容错以及安全的方式提供的。"
@@ -338,19 +338,19 @@ msgid "The record written on the dead letter queue contains a set of additional 
 msgstr "所有写入dead letter queue中的记录将包含一组关于原始记录的附加headers："
 
 msgid "*dead-letter-reason*: the reason of the failure"
-msgstr "*dead-letter-reason* ：失败原因\n"
+msgstr "*dead-letter-reason* ：失败原因"
 
 msgid "*dead-letter-cause*: the cause of the failure if any"
-msgstr "*dead-letter-cause* ：失败的起因(如果有)。\n"
+msgstr "*dead-letter-cause* ：失败的起因(如果有)。"
 
 msgid "*dead-letter-topic*: the original topic of the record"
-msgstr "*dead-letter-topic* ：失败记录的原始topic\n"
+msgstr "*dead-letter-topic* ：失败记录的原始topic"
 
 msgid "*dead-letter-partition*: the original partition of the record (integer mapped to String)"
-msgstr "*dead-letter-partition* ：失败记录的原始分区(integer映射为String)\n"
+msgstr "*dead-letter-partition* ：失败记录的原始分区(integer映射为String)"
 
 msgid "*dead-letter-offset*: the original offset of the record (long mapped to String)"
-msgstr "*dead-letter-offset* ：失败记录的原始偏移量(long映射为String)\n"
+msgstr "*dead-letter-offset* ：失败记录的原始偏移量(long映射为String)"
 
 #, fuzzy
 msgid ""
@@ -418,7 +418,7 @@ msgid "Let's explore briefly different producer/consumer patterns and how to imp
 msgstr "让我们简单展示一下不同的生产者/消费者模式以及如何使用Quarkus来实现它们："
 
 msgid "*Single consumer thread inside a consumer group*"
-msgstr "*消费者组内使用单一消费者线程*\n"
+msgstr "*消费者组内使用单一消费者线程*"
 
 msgid ""
 "This is the default behavior of an application subscribing to a Kafka topic: Each Kafka connector will create a single consumer thread and place it inside a single consumer group.\n"
@@ -427,7 +427,7 @@ msgid ""
 msgstr "这是一个应用程序订阅Kafka topic的默认方式：每个Kafka Connector将创建一个独立的消费者线程，并将其置于一个单独的消费者组内。消费者组id默认为 `quarkus.application.name` 所设定的应用程序名称。它也可以使用 `kafka.group.id` 来设置。"
 
 msgid "*Multiple consumer threads inside a consumer group*"
-msgstr "*一个消费者组内使用多个消费者线程* \n"
+msgstr "*一个消费者组内使用多个消费者线程* "
 
 #, fuzzy
 msgid ""
@@ -447,7 +447,7 @@ msgid ""
 msgstr "link:https://smallrye.io/smallrye-reactive-messaging/latest/concepts/incoming-concurrency/[concurrency 属性提供了一种] 与连接器无关的非阻塞并发通道实现方式，并取代了原有的 Kafka 连接器专用的 `partitions` 属性。因此， `partitions` 属性已被废弃，并将在未来的版本中移除。"
 
 msgid "*Multiple consumer applications inside a consumer group*"
-msgstr "*一个消费者组内有多个消费者应用程序* \n"
+msgstr "*一个消费者组内有多个消费者应用程序* "
 
 msgid ""
 "Similar to the previous example, multiple instances of an application can subscribe to a single consumer group, configured via `mp.messaging.incoming.$channel.group.id` property, or left default to the application name.\n"
@@ -455,7 +455,7 @@ msgid ""
 msgstr "与前面的例子类似，一个应用程序的多个实例可以订阅同一个消费者组。这种方式可以通过 `mp.messaging.incoming.$channel.group.id` 进行配置，或默认为应用程序的名称。这种方式会在应用程序实例之间分配topic的分区。"
 
 msgid "*Pub/Sub: Multiple consumer groups subscribed to a topic*"
-msgstr "*发布/订阅：多个消费者群体订阅同一个topic* \n"
+msgstr "*发布/订阅：多个消费者群体订阅同一个topic* "
 
 msgid ""
 "Lastly different applications can subscribe independently to same topics using different *consumer group ids*.\n"

--- a/l10n/po/zh_CN/content/versions/3.34/guides/vertx.adoc.po
+++ b/l10n/po/zh_CN/content/versions/3.34/guides/vertx.adoc.po
@@ -284,7 +284,7 @@ msgstr ""
 "在终端中，运行以下命令:"
 
 msgid "You should get the expected `Hello bob` message back."
-msgstr "你应该会收到预期的 `Hello bob` 消息。\n"
+msgstr "你应该会收到预期的 `Hello bob` 消息。"
 
 msgid "Using Vert.x Clients"
 msgstr "使用Vert.x客户端"
@@ -348,10 +348,10 @@ msgid "Extract the `langlinks` array from the response."
 msgstr "从响应中提取 `langlinks` 数组。"
 
 msgid "Then, invoke the endpoint using:"
-msgstr "接着，使用以下命令请求该端点:\n"
+msgstr "接着，使用以下命令请求该端点:"
 
 msgid "The response indicates that, in addition to the English page, there are a German and a French page about Quarkus on wikipedia."
-msgstr "该响应表明，除了英文页面，维基百科上还有关于 Quarkus 的德文和法文页面。\n"
+msgstr "该响应表明，除了英文页面，维基百科上还有关于 Quarkus 的德文和法文页面。"
 
 #, fuzzy
 msgid "Executing Asynchronous Code From a Blocking Thread"

--- a/l10n/po/zh_CN/content/versions/3.8/guides/guides.md.po
+++ b/l10n/po/zh_CN/content/versions/3.8/guides/guides.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: content/versions/3.8/guides/guides.md:1
 #, fuzzy, no-wrap
 msgid "documentation"
-msgstr "文档"
+msgstr "documentation"
 
 #. type: Yaml Front Matter Hash Value: link
 #: content/versions/3.8/guides/guides.md:1

--- a/l10n/po/zh_CN/content/versions/3.8/guides/kafka.adoc.po
+++ b/l10n/po/zh_CN/content/versions/3.8/guides/kafka.adoc.po
@@ -22,13 +22,13 @@ msgid ""
 msgstr "link:https://kafka.apache.org[Apache Kafka] 是一个流行的开源分布式事件流平台。它通常用于高性能数据管道、流式分析、数据集成以及任务关键型应用。类似于消息队列或企业消息平台，它可以允许您："
 
 msgid "*publish* (write) and *subscribe* to (read) streams of events, called _records_."
-msgstr "*发布* (写)以及 *订阅* (读)事件流，称为 _记录_ 。\n"
+msgstr "*发布* (写)以及 *订阅* (读)事件流，称为 _记录_ 。"
 
 msgid "*store* streams of records durably and reliably inside _topics_."
-msgstr "在 _topic_ 内持久而可靠地 *存储* 流式记录。\n"
+msgstr "在 _topic_ 内持久而可靠地 *存储* 流式记录。"
 
 msgid "*process* streams of records as they occur or retrospectively."
-msgstr "对流式记录进行起始或回溯*处理*。\n"
+msgstr "对流式记录进行起始或回溯*处理*。"
 
 msgid "And all this functionality is provided in a distributed, highly scalable, elastic, fault-tolerant, and secure manner."
 msgstr "而所有这些功能都是以分布式、高可扩展性、弹性、容错以及安全的方式提供的。"
@@ -329,19 +329,19 @@ msgid "The record written on the dead letter queue contains a set of additional 
 msgstr "所有写入dead letter queue中的记录将包含一组关于原始记录的附加headers："
 
 msgid "*dead-letter-reason*: the reason of the failure"
-msgstr "*dead-letter-reason* ：失败原因\n"
+msgstr "*dead-letter-reason* ：失败原因"
 
 msgid "*dead-letter-cause*: the cause of the failure if any"
-msgstr "*dead-letter-cause* ：失败的起因(如果有)。\n"
+msgstr "*dead-letter-cause* ：失败的起因(如果有)。"
 
 msgid "*dead-letter-topic*: the original topic of the record"
-msgstr "*dead-letter-topic* ：失败记录的原始topic\n"
+msgstr "*dead-letter-topic* ：失败记录的原始topic"
 
 msgid "*dead-letter-partition*: the original partition of the record (integer mapped to String)"
-msgstr "*dead-letter-partition* ：失败记录的原始分区(integer映射为String)\n"
+msgstr "*dead-letter-partition* ：失败记录的原始分区(integer映射为String)"
 
 msgid "*dead-letter-offset*: the original offset of the record (long mapped to String)"
-msgstr "*dead-letter-offset* ：失败记录的原始偏移量(long映射为String)\n"
+msgstr "*dead-letter-offset* ：失败记录的原始偏移量(long映射为String)"
 
 #, fuzzy
 msgid ""
@@ -398,7 +398,7 @@ msgid "Let's explore briefly different producer/consumer patterns and how to imp
 msgstr "让我们简单展示一下不同的生产者/消费者模式以及如何使用Quarkus来实现它们："
 
 msgid "*Single consumer thread inside a consumer group*"
-msgstr "*消费者组内使用单一消费者线程*\n"
+msgstr "*消费者组内使用单一消费者线程*"
 
 msgid ""
 "This is the default behavior of an application subscribing to a Kafka topic: Each Kafka connector will create a single consumer thread and place it inside a single consumer group.\n"
@@ -407,7 +407,7 @@ msgid ""
 msgstr "这是一个应用程序订阅Kafka topic的默认方式：每个Kafka Connector将创建一个独立的消费者线程，并将其置于一个单独的消费者组内。消费者组id默认为 `quarkus.application.name` 所设定的应用程序名称。它也可以使用 `kafka.group.id` 来设置。"
 
 msgid "*Multiple consumer threads inside a consumer group*"
-msgstr "*一个消费者组内使用多个消费者线程* \n"
+msgstr "*一个消费者组内使用多个消费者线程* "
 
 #, fuzzy
 msgid ""
@@ -427,7 +427,7 @@ msgid ""
 msgstr "link:https://smallrye.io/smallrye-reactive-messaging/latest/concepts/incoming-concurrency/[concurrency 属性提供了一种] 与连接器无关的非阻塞并发通道实现方式，并取代了原有的 Kafka 连接器专用的 `partitions` 属性。因此， `partitions` 属性已被废弃，并将在未来的版本中移除。"
 
 msgid "*Multiple consumer applications inside a consumer group*"
-msgstr "*一个消费者组内有多个消费者应用程序* \n"
+msgstr "*一个消费者组内有多个消费者应用程序* "
 
 msgid ""
 "Similar to the previous example, multiple instances of an application can subscribe to a single consumer group, configured via `mp.messaging.incoming.$channel.group.id` property, or left default to the application name.\n"
@@ -435,7 +435,7 @@ msgid ""
 msgstr "与前面的例子类似，一个应用程序的多个实例可以订阅同一个消费者组。这种方式可以通过 `mp.messaging.incoming.$channel.group.id` 进行配置，或默认为应用程序的名称。这种方式会在应用程序实例之间分配topic的分区。"
 
 msgid "*Pub/Sub: Multiple consumer groups subscribed to a topic*"
-msgstr "*发布/订阅：多个消费者群体订阅同一个topic* \n"
+msgstr "*发布/订阅：多个消费者群体订阅同一个topic* "
 
 msgid ""
 "Lastly different applications can subscribe independently to same topics using different *consumer group ids*.\n"

--- a/l10n/po/zh_CN/content/versions/3.8/guides/vertx.adoc.po
+++ b/l10n/po/zh_CN/content/versions/3.8/guides/vertx.adoc.po
@@ -282,7 +282,7 @@ msgstr ""
 "在终端中，运行以下命令:"
 
 msgid "You should get the expected `Hello bob` message back."
-msgstr "你应该会收到预期的 `Hello bob` 消息。\n"
+msgstr "你应该会收到预期的 `Hello bob` 消息。"
 
 msgid "Using Vert.x Clients"
 msgstr "使用Vert.x客户端"
@@ -346,10 +346,10 @@ msgid "Extract the `langlinks` array from the response."
 msgstr "从响应中提取 `langlinks` 数组。"
 
 msgid "Then, invoke the endpoint using:"
-msgstr "接着，使用以下命令请求该端点:\n"
+msgstr "接着，使用以下命令请求该端点:"
 
 msgid "The response indicates that, in addition to the English page, there are a German and a French page about Quarkus on wikipedia."
-msgstr "该响应表明，除了英文页面，维基百科上还有关于 Quarkus 的德文和法文页面。\n"
+msgstr "该响应表明，除了英文页面，维基百科上还有关于 Quarkus 的德文和法文页面。"
 
 #, fuzzy
 msgid "Executing Asynchronous Code From a Blocking Thread"

--- a/l10n/po/zh_CN/content/versions/main/guides/guides.md.po
+++ b/l10n/po/zh_CN/content/versions/main/guides/guides.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: content/versions/main/guides/guides.md:1
 #, fuzzy, no-wrap
 msgid "documentation"
-msgstr "文档"
+msgstr "documentation"
 
 #. type: Yaml Front Matter Hash Value: link
 #: content/versions/main/guides/guides.md:1

--- a/l10n/po/zh_CN/content/versions/main/guides/kafka.adoc.po
+++ b/l10n/po/zh_CN/content/versions/main/guides/kafka.adoc.po
@@ -24,13 +24,13 @@ msgid ""
 msgstr "link:https://kafka.apache.org[Apache Kafka] 是一个流行的开源分布式事件流平台。它通常用于高性能数据管道、流式分析、数据集成以及任务关键型应用。类似于消息队列或企业消息平台，它可以允许您："
 
 msgid "*publish* (write) and *subscribe* to (read) streams of events, called _records_."
-msgstr "*发布* (写)以及 *订阅* (读)事件流，称为 _记录_ 。\n"
+msgstr "*发布* (写)以及 *订阅* (读)事件流，称为 _记录_ 。"
 
 msgid "*store* streams of records durably and reliably inside _topics_."
-msgstr "在 _topic_ 内持久而可靠地 *存储* 流式记录。\n"
+msgstr "在 _topic_ 内持久而可靠地 *存储* 流式记录。"
 
 msgid "*process* streams of records as they occur or retrospectively."
-msgstr "对流式记录进行起始或回溯*处理*。\n"
+msgstr "对流式记录进行起始或回溯*处理*。"
 
 msgid "And all this functionality is provided in a distributed, highly scalable, elastic, fault-tolerant, and secure manner."
 msgstr "而所有这些功能都是以分布式、高可扩展性、弹性、容错以及安全的方式提供的。"
@@ -344,19 +344,19 @@ msgid "The record written on the dead letter queue contains a set of additional 
 msgstr "所有写入dead letter queue中的记录将包含一组关于原始记录的附加headers："
 
 msgid "*dead-letter-reason*: the reason of the failure"
-msgstr "*dead-letter-reason* ：失败原因\n"
+msgstr "*dead-letter-reason* ：失败原因"
 
 msgid "*dead-letter-cause*: the cause of the failure if any"
-msgstr "*dead-letter-cause* ：失败的起因(如果有)。\n"
+msgstr "*dead-letter-cause* ：失败的起因(如果有)。"
 
 msgid "*dead-letter-topic*: the original topic of the record"
-msgstr "*dead-letter-topic* ：失败记录的原始topic\n"
+msgstr "*dead-letter-topic* ：失败记录的原始topic"
 
 msgid "*dead-letter-partition*: the original partition of the record (integer mapped to String)"
-msgstr "*dead-letter-partition* ：失败记录的原始分区(integer映射为String)\n"
+msgstr "*dead-letter-partition* ：失败记录的原始分区(integer映射为String)"
 
 msgid "*dead-letter-offset*: the original offset of the record (long mapped to String)"
-msgstr "*dead-letter-offset* ：失败记录的原始偏移量(long映射为String)\n"
+msgstr "*dead-letter-offset* ：失败记录的原始偏移量(long映射为String)"
 
 #, fuzzy
 msgid ""
@@ -424,7 +424,7 @@ msgid "Let's explore briefly different producer/consumer patterns and how to imp
 msgstr "让我们简单展示一下不同的生产者/消费者模式以及如何使用Quarkus来实现它们："
 
 msgid "*Single consumer thread inside a consumer group*"
-msgstr "*消费者组内使用单一消费者线程*\n"
+msgstr "*消费者组内使用单一消费者线程*"
 
 msgid ""
 "This is the default behavior of an application subscribing to a Kafka topic: Each Kafka connector will create a single consumer thread and place it inside a single consumer group.\n"
@@ -433,7 +433,7 @@ msgid ""
 msgstr "这是一个应用程序订阅Kafka topic的默认方式：每个Kafka Connector将创建一个独立的消费者线程，并将其置于一个单独的消费者组内。消费者组id默认为 `quarkus.application.name` 所设定的应用程序名称。它也可以使用 `kafka.group.id` 来设置。"
 
 msgid "*Multiple consumer threads inside a consumer group*"
-msgstr "*一个消费者组内使用多个消费者线程* \n"
+msgstr "*一个消费者组内使用多个消费者线程* "
 
 #, fuzzy
 msgid ""
@@ -453,7 +453,7 @@ msgid ""
 msgstr "link:https://smallrye.io/smallrye-reactive-messaging/latest/concepts/incoming-concurrency/[concurrency 属性提供了一种] 与连接器无关的非阻塞并发通道实现方式，并取代了原有的 Kafka 连接器专用的 `partitions` 属性。因此， `partitions` 属性已被废弃，并将在未来的版本中移除。"
 
 msgid "*Multiple consumer applications inside a consumer group*"
-msgstr "*一个消费者组内有多个消费者应用程序* \n"
+msgstr "*一个消费者组内有多个消费者应用程序* "
 
 msgid ""
 "Similar to the previous example, multiple instances of an application can subscribe to a single consumer group, configured via `mp.messaging.incoming.$channel.group.id` property, or left default to the application name.\n"
@@ -461,7 +461,7 @@ msgid ""
 msgstr "与前面的例子类似，一个应用程序的多个实例可以订阅同一个消费者组。这种方式可以通过 `mp.messaging.incoming.$channel.group.id` 进行配置，或默认为应用程序的名称。这种方式会在应用程序实例之间分配topic的分区。"
 
 msgid "*Pub/Sub: Multiple consumer groups subscribed to a topic*"
-msgstr "*发布/订阅：多个消费者群体订阅同一个topic* \n"
+msgstr "*发布/订阅：多个消费者群体订阅同一个topic* "
 
 msgid ""
 "Lastly different applications can subscribe independently to same topics using different *consumer group ids*.\n"

--- a/l10n/po/zh_CN/content/versions/main/guides/vertx.adoc.po
+++ b/l10n/po/zh_CN/content/versions/main/guides/vertx.adoc.po
@@ -285,7 +285,7 @@ msgstr ""
 "在终端中，运行以下命令:"
 
 msgid "You should get the expected `Hello bob` message back."
-msgstr "你应该会收到预期的 `Hello bob` 消息。\n"
+msgstr "你应该会收到预期的 `Hello bob` 消息。"
 
 msgid "Using Vert.x Clients"
 msgstr "使用Vert.x客户端"
@@ -349,10 +349,10 @@ msgid "Extract the `langlinks` array from the response."
 msgstr "从响应中提取 `langlinks` 数组。"
 
 msgid "Then, invoke the endpoint using:"
-msgstr "接着，使用以下命令请求该端点:\n"
+msgstr "接着，使用以下命令请求该端点:"
 
 msgid "The response indicates that, in addition to the English page, there are a German and a French page about Quarkus on wikipedia."
-msgstr "该响应表明，除了英文页面，维基百科上还有关于 Quarkus 的德文和法文页面。\n"
+msgstr "该响应表明，除了英文页面，维基百科上还有关于 Quarkus 的德文和法文页面。"
 
 #, fuzzy
 msgid "Executing Asynchronous Code From a Blocking Thread"

--- a/l10n/po/zh_CN/content/wg.md.po
+++ b/l10n/po/zh_CN/content/wg.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: content/wg.md:1
 #, fuzzy, no-wrap
 msgid "working-groups"
-msgstr "工作组"
+msgstr "working-groups"
 
 #. type: Yaml Front Matter Hash Value: link
 #: content/wg.md:1

--- a/l10n/po/zh_CN/desktopwallpapers.md.po
+++ b/l10n/po/zh_CN/desktopwallpapers.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: desktopwallpapers.md:1
 #, fuzzy, no-wrap
 msgid "desktop_wallpaper"
-msgstr "桌面壁纸"
+msgstr "desktop_wallpaper"
 
 #. type: Yaml Front Matter Hash Value: permalink
 #: desktopwallpapers.md:1

--- a/l10n/po/zh_CN/developer-joy.md.po
+++ b/l10n/po/zh_CN/developer-joy.md.po
@@ -14,7 +14,7 @@ msgstr ""
 #: developer-joy.md:1
 #, fuzzy, no-wrap
 msgid "developer-joy"
-msgstr "开发者之乐"
+msgstr "developer-joy"
 
 #. type: Yaml Front Matter Hash Value: permalink
 #: developer-joy.md:1

--- a/l10n/po/zh_CN/discussion.md.po
+++ b/l10n/po/zh_CN/discussion.md.po
@@ -14,7 +14,7 @@ msgstr ""
 #: discussion.md:1
 #, fuzzy, no-wrap
 msgid "discussion"
-msgstr "讨论"
+msgstr "discussion"
 
 #. type: Yaml Front Matter Hash Value: permalink
 #: discussion.md:1

--- a/l10n/po/zh_CN/events.md.po
+++ b/l10n/po/zh_CN/events.md.po
@@ -14,7 +14,7 @@ msgstr ""
 #: events.md:1
 #, fuzzy, no-wrap
 msgid "events"
-msgstr "活动"
+msgstr "events"
 
 #. type: Yaml Front Matter Hash Value: permalink
 #: events.md:1

--- a/l10n/po/zh_CN/faq.adoc.po
+++ b/l10n/po/zh_CN/faq.adoc.po
@@ -100,17 +100,17 @@ msgstr "扩展在进入Quarkus生态系统时具有不同程度的成熟度。�
 #. type: Plain text
 #: faq.adoc
 msgid "*Stable*: backward compatibility and presence in the ecosystem are taken very seriously. An application can safely rely on these extensions. Extensions not marked as preview or experimental (the majority) are stable."
-msgstr "*Stable*: 向后兼容性和在生态系统中的存在被非常重视。应用程序可以安全地依赖于这些扩展。没有标记为预览或实验的扩展(大多数)是稳定的。\n"
+msgstr "*Stable*: 向后兼容性和在生态系统中的存在被非常重视。应用程序可以安全地依赖于这些扩展。没有标记为预览或实验的扩展(大多数)是稳定的。"
 
 #. type: Plain text
 #: faq.adoc
 msgid "*Preview*: backward compatibility and presence in the ecosystem is not guaranteed. Specific improvements might require to change configuration or APIs and plans to become _stable_ are under way. Such extensions are in the middle of their maturation process."
-msgstr "*Preview*: 不能保证向后兼容性和在生态系统中的存在。具体的改进可能需要改变配置、API和计划，使之变得 _stable_ 。这些扩展还处于成熟过程的中间阶段。\n"
+msgstr "*Preview*: 不能保证向后兼容性和在生态系统中的存在。具体的改进可能需要改变配置、API和计划，使之变得 _stable_ 。这些扩展还处于成熟过程的中间阶段。"
 
 #. type: Plain text
 #: faq.adoc
 msgid "*Experimental*: early feedback is requested to mature the idea. There is no guarantee of stability nor long term presence in the platform until the solution matures. Such extensions are at the beginning of their maturation process."
-msgstr "*Experimental*: 尽早反馈，以使想法更加成熟。在解决方案成熟之前，无法保证平台的稳定性或长期存在。这些扩展正处于其成熟过程的开始阶段。\n"
+msgstr "*Experimental*: 尽早反馈，以使想法更加成熟。在解决方案成熟之前，无法保证平台的稳定性或长期存在。这些扩展正处于其成熟过程的开始阶段。"
 
 #. type: Plain text
 #: faq.adoc

--- a/l10n/po/zh_CN/foundation-faq.md.po
+++ b/l10n/po/zh_CN/foundation-faq.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: foundation-faq.md:1
 #, fuzzy, no-wrap
 msgid "usage"
-msgstr "用法"
+msgstr "usage"
 
 #. type: Yaml Front Matter Hash Value: permalink
 #: foundation-faq.md:1

--- a/l10n/po/zh_CN/foundation.md.po
+++ b/l10n/po/zh_CN/foundation.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: foundation.md:1
 #, fuzzy, no-wrap
 msgid "usage"
-msgstr "用法"
+msgstr "usage"
 
 #. type: Yaml Front Matter Hash Value: permalink
 #: foundation.md:1

--- a/l10n/po/zh_CN/index.md.po
+++ b/l10n/po/zh_CN/index.md.po
@@ -14,7 +14,7 @@ msgstr ""
 #: index.md:1
 #, fuzzy, no-wrap
 msgid "index"
-msgstr "索引"
+msgstr "index"
 
 #. type: Yaml Front Matter Hash Value: title
 #: index.md:1

--- a/l10n/po/zh_CN/insights.md.po
+++ b/l10n/po/zh_CN/insights.md.po
@@ -14,7 +14,7 @@ msgstr ""
 #: insights.md:1
 #, fuzzy, no-wrap
 msgid "insights"
-msgstr "见解"
+msgstr "insights"
 
 #. type: Yaml Front Matter Hash Value: permalink
 #: insights.md:1

--- a/l10n/po/zh_CN/newsletter.md.po
+++ b/l10n/po/zh_CN/newsletter.md.po
@@ -14,7 +14,7 @@ msgstr ""
 #: newsletter.md:1
 #, fuzzy, no-wrap
 msgid "newsletter"
-msgstr "通讯"
+msgstr "newsletter"
 
 #. type: Yaml Front Matter Hash Value: permalink
 #: newsletter.md:1

--- a/l10n/po/zh_CN/performance.md.po
+++ b/l10n/po/zh_CN/performance.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: performance.md:1
 #, fuzzy, no-wrap
 msgid "performance"
-msgstr "性能测量.adoc"
+msgstr "performance"
 
 #. type: Yaml Front Matter Hash Value: permalink
 #: performance.md:1

--- a/l10n/po/zh_CN/releases.md.po
+++ b/l10n/po/zh_CN/releases.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: releases.md:1
 #, fuzzy, no-wrap
 msgid "releases"
-msgstr "发布"
+msgstr "releases"
 
 #. type: Yaml Front Matter Hash Value: permalink
 #: releases.md:1

--- a/l10n/po/zh_CN/sitemap.md.po
+++ b/l10n/po/zh_CN/sitemap.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: sitemap.md:1
 #, fuzzy, no-wrap
 msgid "sitemap"
-msgstr "网站地图"
+msgstr "sitemap"
 
 #. type: Yaml Front Matter Hash Value: permalink
 #: sitemap.md:1

--- a/l10n/po/zh_CN/socials.md.po
+++ b/l10n/po/zh_CN/socials.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: socials.md:1
 #, fuzzy, no-wrap
 msgid "socials"
-msgstr "社交活动"
+msgstr "socials"
 
 #. type: Yaml Front Matter Hash Value: permalink
 #: socials.md:1

--- a/l10n/po/zh_CN/spring.md.po
+++ b/l10n/po/zh_CN/spring.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: spring.md:1
 #, fuzzy, no-wrap
 msgid "spring"
-msgstr "春天"
+msgstr "spring"
 
 #. type: Yaml Front Matter Hash Value: permalink
 #: spring.md:1

--- a/l10n/po/zh_CN/standards.md.po
+++ b/l10n/po/zh_CN/standards.md.po
@@ -14,7 +14,7 @@ msgstr ""
 #: standards.md:1
 #, fuzzy, no-wrap
 msgid "standards"
-msgstr "标准"
+msgstr "standards"
 
 #. type: Yaml Front Matter Hash Value: permalink
 #: standards.md:1

--- a/l10n/po/zh_CN/stickers.md.po
+++ b/l10n/po/zh_CN/stickers.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: stickers.md:1
 #, fuzzy, no-wrap
 msgid "stickers"
-msgstr "贴纸"
+msgstr "stickers"
 
 #. type: Yaml Front Matter Hash Value: permalink
 #: stickers.md:1

--- a/l10n/po/zh_CN/support.md.po
+++ b/l10n/po/zh_CN/support.md.po
@@ -14,7 +14,7 @@ msgstr ""
 #: support.md:1
 #, fuzzy, no-wrap
 msgid "support"
-msgstr "支持"
+msgstr "support"
 
 #. type: Yaml Front Matter Hash Value: permalink
 #: support.md:1

--- a/l10n/po/zh_CN/usage.md.po
+++ b/l10n/po/zh_CN/usage.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: usage.md:1
 #, fuzzy, no-wrap
 msgid "usage"
-msgstr "用法"
+msgstr "usage"
 
 #. type: Yaml Front Matter Hash Value: permalink
 #: usage.md:1

--- a/l10n/po/zh_CN/usage_policy.md.po
+++ b/l10n/po/zh_CN/usage_policy.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: usage_policy.md:1
 #, fuzzy, no-wrap
 msgid "usagepolicy"
-msgstr "使用政策"
+msgstr "usagepolicy"
 
 #. type: Yaml Front Matter Hash Value: permalink
 #: usage_policy.md:1

--- a/l10n/po/zh_CN/wg.md.po
+++ b/l10n/po/zh_CN/wg.md.po
@@ -13,7 +13,7 @@ msgstr ""
 #: wg.md:1
 #, fuzzy, no-wrap
 msgid "working-groups"
-msgstr "工作组"
+msgstr "working-groups"
 
 #. type: Yaml Front Matter Hash Value: permalink
 #: wg.md:1


### PR DESCRIPTION
Includes fixes from #297 and #298, plus additional updates:

- Fix CNAME configuration for ROQ deployment (#297)
- Update tsuji to 0.9.2 (fixes "Payload too large" error with DeepL API)
- Bump GitHub Actions versions (checkout@v7, setup-java@v6, cache@v6, download-artifact@v8)
- Fix pr-deploy for fork pull requests (use pulls.list instead of listPullRequestsAssociatedWithCommit)